### PR TITLE
Add `inFlight` method for effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Debug](#debug)
 - [Delay](#delay)
 - [Every](#every)
+- [InFlight](#inflight)
 - [Reshape](#reshape)
 - [Some](#some)
 - [SplitMap](#splitmap)
@@ -233,6 +234,21 @@ const $isFormCorrect = every({
   stores: [$isPasswordCorrect, $isEmailCorrect],
 });
 // true
+```
+
+## [InFlight](/in-flight 'Documentation')
+
+```ts
+const firstFx = createEffect();
+const secondFx = createEffect();
+
+const $allInFlight = inFlight({ effects: [firstFx, secondFx] });
+
+firstFx();
+secondFx();
+firstFx();
+
+$allInFlight.watch(console.log); // 3
 ```
 
 ## [Some](/some 'Documentation')

--- a/babel-preset-plugins.json
+++ b/babel-preset-plugins.json
@@ -9,6 +9,7 @@
         "debounce",
         "delay",
         "every",
+        "inFlight",
         "pending",
         "reshape",
         "some",
@@ -65,6 +66,15 @@
       "noDefaults": true
     },
     "patronum/every"
+  ],
+  [
+    "effector/babel-plugin",
+    {
+      "importName": "patronum/in-flight",
+      "attachCreators": ["inFlight"],
+      "noDefaults": true
+    },
+    "patronum/in-flight"
   ],
   [
     "effector/babel-plugin",

--- a/in-flight/in-flight.fork.test.ts
+++ b/in-flight/in-flight.fork.test.ts
@@ -2,42 +2,86 @@ import { createDomain, forward } from 'effector';
 import { fork, allSettled } from 'effector/fork';
 import { inFlight } from '.';
 
-test('works in forked scope', async () => {
-  const app = createDomain();
-  const effect1 = app.createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
-  });
-  const effect2 = app.createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
-  });
-  const $count = inFlight({ effects: [effect1, effect2] });
-  const scope = fork(app);
+describe('effects', () => {
+  test('works in forked scope', async () => {
+    const app = createDomain();
+    const effect1 = app.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const effect2 = app.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const $count = inFlight({ effects: [effect1, effect2] });
+    const scope = fork(app);
 
-  const finish = allSettled(effect1, { scope });
-  expect(scope.getState($count)).toMatchInlineSnapshot(`1`);
+    const finish = allSettled(effect1, { scope });
+    expect(scope.getState($count)).toMatchInlineSnapshot(`1`);
 
-  await finish;
-  expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+    await finish;
+    expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+  });
+
+  test('concurrent run of different effects', async () => {
+    const app = createDomain();
+    const effect1 = app.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect2 = app.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 50)),
+    });
+    const $count = inFlight({ effects: [effect1, effect2] });
+    const run = app.createEvent();
+    forward({ from: run, to: [effect1, effect2] });
+
+    const scope = fork(app);
+    expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+
+    const finish = allSettled(run, { scope });
+    expect(scope.getState($count)).toMatchInlineSnapshot(`2`);
+
+    await finish;
+    expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+  });
 });
 
-test('concurrent run of different effects', async () => {
-  const app = createDomain();
-  const effect1 = app.createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+describe('domain', () => {
+  test('works in forked scope', async () => {
+    const domain = createDomain();
+    const effect1 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const effect2 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const $count = inFlight({ domain });
+    const scope = fork(domain);
+
+    const finish = allSettled(effect1, { scope });
+    expect(scope.getState($count)).toMatchInlineSnapshot(`1`);
+
+    await finish;
+    expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
   });
-  const effect2 = app.createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 50)),
+
+  test('concurrent run of different effects', async () => {
+    const domain = createDomain();
+    const effect1 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect2 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 50)),
+    });
+    const $count = inFlight({ domain });
+    const run = domain.createEvent();
+    forward({ from: run, to: [effect1, effect2] });
+
+    const scope = fork(domain);
+    expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+
+    const finish = allSettled(run, { scope });
+    expect(scope.getState($count)).toMatchInlineSnapshot(`2`);
+
+    await finish;
+    expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
   });
-  const $count = inFlight({ effects: [effect1, effect2] });
-  const run = app.createEvent();
-  forward({ from: run, to: [effect1, effect2] });
-
-  const scope = fork(app);
-  expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
-
-  const finish = allSettled(run, { scope });
-  expect(scope.getState($count)).toMatchInlineSnapshot(`2`);
-
-  await finish;
-  expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
 });

--- a/in-flight/in-flight.fork.test.ts
+++ b/in-flight/in-flight.fork.test.ts
@@ -1,0 +1,43 @@
+import { createDomain, forward } from 'effector';
+import { fork, allSettled } from 'effector/fork';
+import { inFlight } from '.';
+
+test('works in forked scope', async () => {
+  const app = createDomain();
+  const effect1 = app.createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+  });
+  const effect2 = app.createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+  });
+  const $count = inFlight({ effects: [effect1, effect2] });
+  const scope = fork(app);
+
+  const finish = allSettled(effect1, { scope });
+  expect(scope.getState($count)).toMatchInlineSnapshot(`1`);
+
+  await finish;
+  expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+});
+
+test('concurrent run of different effects', async () => {
+  const app = createDomain();
+  const effect1 = app.createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+  });
+  const effect2 = app.createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 50)),
+  });
+  const $count = inFlight({ effects: [effect1, effect2] });
+  const run = app.createEvent();
+  forward({ from: run, to: [effect1, effect2] });
+
+  const scope = fork(app);
+  expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+
+  const finish = allSettled(run, { scope });
+  expect(scope.getState($count)).toMatchInlineSnapshot(`2`);
+
+  await finish;
+  expect(scope.getState($count)).toMatchInlineSnapshot(`0`);
+});

--- a/in-flight/in-flight.test.ts
+++ b/in-flight/in-flight.test.ts
@@ -1,72 +1,73 @@
-import { createEffect, combine } from 'effector';
+import { createEffect, combine, createDomain } from 'effector';
 import { argumentHistory, waitFor } from '../test-library';
 import { inFlight } from './index';
 
-test('initial at 0', async () => {
-  const effect = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
-  });
-  const $count = inFlight({ effects: [effect] });
-  const fn = jest.fn();
+describe('effects', () => {
+  test('initial at 0', async () => {
+    const effect = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const $count = inFlight({ effects: [effect] });
+    const fn = jest.fn();
 
-  $count.watch(fn);
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
     ]
   `);
-});
-
-test('Run effect to get 1, after effect get 0', async () => {
-  const effect = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
   });
-  const $count = inFlight({ effects: [effect] });
-  const fn = jest.fn();
 
-  $count.watch(fn);
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+  test('Run effect to get 1, after effect get 0', async () => {
+    const effect = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const $count = inFlight({ effects: [effect] });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
     ]
   `);
 
-  effect();
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    effect();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
     ]
   `);
 
-  await waitFor(effect.finally);
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    await waitFor(effect.finally);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
       0,
     ]
   `);
-});
-
-test('Concurrent runs works simultaneously', async () => {
-  const effect = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 100)),
   });
-  const $count = inFlight({ effects: [effect] });
-  const fn = jest.fn();
 
-  $count.watch(fn);
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+  test('Concurrent runs works simultaneously', async () => {
+    const effect = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 100)),
+    });
+    const $count = inFlight({ effects: [effect] });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
     ]
   `);
 
-  effect();
-  effect();
-  effect();
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    effect();
+    effect();
+    effect();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
@@ -75,8 +76,8 @@ test('Concurrent runs works simultaneously', async () => {
     ]
   `);
 
-  await waitFor(effect.inFlight.updates.filter({ fn: (c) => c === 0 }));
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    await waitFor(effect.inFlight.updates.filter({ fn: (c) => c === 0 }));
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
@@ -87,38 +88,38 @@ test('Concurrent runs works simultaneously', async () => {
       0,
     ]
   `);
-});
+  });
 
-test('Different effects works simultaneously', async () => {
-  const effect1 = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
-  });
-  const effect2 = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
-  });
-  const effect3 = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
-  });
-  const $count = inFlight({ effects: [effect1, effect2, effect3] });
-  const fn = jest.fn();
+  test('Different effects works simultaneously', async () => {
+    const effect1 = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect2 = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect3 = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const $count = inFlight({ effects: [effect1, effect2, effect3] });
+    const fn = jest.fn();
 
-  $count.watch(fn);
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
     ]
   `);
 
-  effect1();
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    effect1();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
     ]
   `);
 
-  await waitFor(effect1.inFlight.updates.filter({ fn: (c) => c === 0 }));
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    await waitFor(effect1.inFlight.updates.filter({ fn: (c) => c === 0 }));
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
@@ -126,8 +127,8 @@ test('Different effects works simultaneously', async () => {
     ]
   `);
 
-  effect2();
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    effect2();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
@@ -136,8 +137,8 @@ test('Different effects works simultaneously', async () => {
     ]
   `);
 
-  await waitFor(effect2.inFlight.updates.filter({ fn: (c) => c === 0 }));
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    await waitFor(effect2.inFlight.updates.filter({ fn: (c) => c === 0 }));
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
@@ -146,31 +147,31 @@ test('Different effects works simultaneously', async () => {
       0,
     ]
   `);
-});
-
-test('Different concurrent effect runs works simultaneously', async () => {
-  const effect1 = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
   });
-  const effect2 = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
-  });
-  const effect3 = createEffect({
-    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
-  });
-  const $count = inFlight({ effects: [effect1, effect2, effect3] });
-  const fn = jest.fn();
 
-  $count.watch(fn);
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+  test('Different concurrent effect runs works simultaneously', async () => {
+    const effect1 = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect2 = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect3 = createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const $count = inFlight({ effects: [effect1, effect2, effect3] });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
     ]
   `);
 
-  effect1();
-  effect2();
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    effect1();
+    effect2();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
@@ -178,14 +179,14 @@ test('Different concurrent effect runs works simultaneously', async () => {
     ]
   `);
 
-  await waitFor(
-    combine(
-      effect2.inFlight,
-      effect1.inFlight,
-      (a, b) => a + b,
-    ).updates.filter({ fn: (c) => c === 0 }),
-  );
-  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    await waitFor(
+      combine(
+        effect2.inFlight,
+        effect1.inFlight,
+        (a, b) => a + b,
+      ).updates.filter({ fn: (c) => c === 0 }),
+    );
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
     Array [
       0,
       1,
@@ -194,4 +195,206 @@ test('Different concurrent effect runs works simultaneously', async () => {
       0,
     ]
   `);
+  });
+});
+
+describe('domain', () => {
+  test('initial at 0', async () => {
+    const domain = createDomain();
+    domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const $count = inFlight({ domain });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+  });
+
+  test('Run effect to get 1, after effect get 0', async () => {
+    const domain = createDomain();
+    const effect = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+    });
+    const $count = inFlight({ domain });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+    effect();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+    ]
+  `);
+
+    await waitFor(effect.finally);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+    ]
+  `);
+  });
+
+  test('Concurrent runs works simultaneously', async () => {
+    const domain = createDomain();
+    const effect = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 100)),
+    });
+    const $count = inFlight({ domain });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+    effect();
+    effect();
+    effect();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+      3,
+    ]
+  `);
+
+    await waitFor(effect.inFlight.updates.filter({ fn: (c) => c === 0 }));
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+      3,
+      2,
+      1,
+      0,
+    ]
+  `);
+  });
+
+  test('Different effects works simultaneously', async () => {
+    const domain = createDomain();
+    const effect1 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect2 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect3 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const $count = inFlight({ domain });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+    effect1();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+    ]
+  `);
+
+    await waitFor(effect1.inFlight.updates.filter({ fn: (c) => c === 0 }));
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+    ]
+  `);
+
+    effect2();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+      1,
+    ]
+  `);
+
+    await waitFor(effect2.inFlight.updates.filter({ fn: (c) => c === 0 }));
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+      1,
+      0,
+    ]
+  `);
+  });
+
+  test('Different concurrent effect runs works simultaneously', async () => {
+    const domain = createDomain();
+    const effect1 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect2 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const effect3 = domain.createEffect({
+      handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+    });
+    const $count = inFlight({ domain });
+    const fn = jest.fn();
+
+    $count.watch(fn);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+    effect1();
+    effect2();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+    ]
+  `);
+
+    await waitFor(
+      combine(
+        effect2.inFlight,
+        effect1.inFlight,
+        (a, b) => a + b,
+      ).updates.filter({ fn: (c) => c === 0 }),
+    );
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+      1,
+      0,
+    ]
+  `);
+  });
 });

--- a/in-flight/in-flight.test.ts
+++ b/in-flight/in-flight.test.ts
@@ -1,0 +1,197 @@
+import { createEffect, combine } from 'effector';
+import { argumentHistory, waitFor } from '../test-library';
+import { inFlight } from './index';
+
+test('initial at 0', async () => {
+  const effect = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+  });
+  const $count = inFlight({ effects: [effect] });
+  const fn = jest.fn();
+
+  $count.watch(fn);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+});
+
+test('Run effect to get 1, after effect get 0', async () => {
+  const effect = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 1)),
+  });
+  const $count = inFlight({ effects: [effect] });
+  const fn = jest.fn();
+
+  $count.watch(fn);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+  effect();
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+    ]
+  `);
+
+  await waitFor(effect.finally);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+    ]
+  `);
+});
+
+test('Concurrent runs works simultaneously', async () => {
+  const effect = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 100)),
+  });
+  const $count = inFlight({ effects: [effect] });
+  const fn = jest.fn();
+
+  $count.watch(fn);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+  effect();
+  effect();
+  effect();
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+      3,
+    ]
+  `);
+
+  await waitFor(effect.inFlight.updates.filter({ fn: (c) => c === 0 }));
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+      3,
+      2,
+      1,
+      0,
+    ]
+  `);
+});
+
+test('Different effects works simultaneously', async () => {
+  const effect1 = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+  });
+  const effect2 = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+  });
+  const effect3 = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+  });
+  const $count = inFlight({ effects: [effect1, effect2, effect3] });
+  const fn = jest.fn();
+
+  $count.watch(fn);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+  effect1();
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+    ]
+  `);
+
+  await waitFor(effect1.inFlight.updates.filter({ fn: (c) => c === 0 }));
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+    ]
+  `);
+
+  effect2();
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+      1,
+    ]
+  `);
+
+  await waitFor(effect2.inFlight.updates.filter({ fn: (c) => c === 0 }));
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      0,
+      1,
+      0,
+    ]
+  `);
+});
+
+test('Different concurrent effect runs works simultaneously', async () => {
+  const effect1 = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+  });
+  const effect2 = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+  });
+  const effect3 = createEffect({
+    handler: () => new Promise((resolve) => setTimeout(resolve, 10)),
+  });
+  const $count = inFlight({ effects: [effect1, effect2, effect3] });
+  const fn = jest.fn();
+
+  $count.watch(fn);
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+    ]
+  `);
+
+  effect1();
+  effect2();
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+    ]
+  `);
+
+  await waitFor(
+    combine(
+      effect2.inFlight,
+      effect1.inFlight,
+      (a, b) => a + b,
+    ).updates.filter({ fn: (c) => c === 0 }),
+  );
+  expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      0,
+      1,
+      2,
+      1,
+      0,
+    ]
+  `);
+});

--- a/in-flight/index.d.ts
+++ b/in-flight/index.d.ts
@@ -1,5 +1,7 @@
-import { Store, Effect } from 'effector';
+import { Store, Effect, Domain } from 'effector';
 
 export function inFlight(_: {
   effects: Array<Effect<any, any, any>>;
 }): Store<number>;
+
+export function inFlight(_: { domain: Domain }): Store<number>;

--- a/in-flight/index.d.ts
+++ b/in-flight/index.d.ts
@@ -1,0 +1,5 @@
+import { Store, Effect } from 'effector';
+
+export function inFlight(_: {
+  effects: Array<Effect<any, any, any>>;
+}): Store<number>;

--- a/in-flight/index.js
+++ b/in-flight/index.js
@@ -1,0 +1,13 @@
+const { combine } = require('effector');
+const { readConfig } = require('../library');
+
+function inFlight(argument) {
+  const { effects } = readConfig(argument, ['effects']);
+
+  return combine(
+    effects.map((fx) => fx.inFlight),
+    (inFlights) => inFlights.reduce((all, current) => all + current, 0),
+  );
+}
+
+module.exports = { inFlight };

--- a/in-flight/index.js
+++ b/in-flight/index.js
@@ -2,7 +2,26 @@ const { combine } = require('effector');
 const { readConfig } = require('../library');
 
 function inFlight(argument) {
-  const { effects } = readConfig(argument, ['effects']);
+  const { effects, domain, sid, name, loc } = readConfig(argument, [
+    'effects',
+    'domain',
+
+    'sid',
+    'name',
+    'loc',
+  ]);
+
+  if (domain) {
+    const $inFlight = domain.createStore(0, { sid, name, loc });
+
+    domain.onCreateEffect((fx) => {
+      $inFlight
+        .on(fx, (count) => count + 1)
+        .on(fx.finally, (count) => count - 1);
+    });
+
+    return $inFlight;
+  }
 
   return combine(
     effects.map((fx) => fx.inFlight),

--- a/in-flight/readme.md
+++ b/in-flight/readme.md
@@ -1,8 +1,10 @@
 # Patronum/InFlight
 
 ```ts
-import { inFlight } from 'patronum/inFlight';
+import { inFlight } from 'patronum/in-flight';
 ```
+
+## `inFlight({ effects: [] })`
 
 ### Formulae
 
@@ -29,6 +31,50 @@ import { inFlight } from 'patronum/in-flight';
 const loadFirst = createEffect().use(() => Promise.resolve(null));
 const loadSecond = createEffect().use(() => Promise.resolve(2));
 const $count = inFlight({ effects: [loadFirst, loadSecond] });
+
+$count.watch((count) => console.info(`count: ${count}`));
+// => count: 0
+
+loadFirst();
+loadSecond();
+// => count: 2
+
+loadSecond();
+loadSecond();
+// => count: 4
+
+// Wait to resolve all effects
+// => count: 0
+```
+
+## `inFlight({ domain })`
+
+### Formulae
+
+```ts
+$count = inFlight({ domain });
+```
+
+- Count all pending runs of effects in passed domain in one store
+
+### Arguments
+
+1. `domain` _(Domain)_ - domain to count effects from
+
+## Returns
+
+- `$count` _(Store<number>)_ - Store with count of run effects in pending state
+
+## Example
+
+```ts
+import { createDomain } from 'effector';
+import { inFlight } from 'patronum/in-flight';
+
+const app = createDomain();
+const loadFirst = app.createEffect().use(() => Promise.resolve(null));
+const loadSecond = app.createEffect().use(() => Promise.resolve(2));
+const $count = inFlight({ domain: app });
 
 $count.watch((count) => console.info(`count: ${count}`));
 // => count: 0

--- a/in-flight/readme.md
+++ b/in-flight/readme.md
@@ -1,0 +1,46 @@
+# Patronum/InFlight
+
+```ts
+import { inFlight } from 'patronum/inFlight';
+```
+
+### Formulae
+
+```ts
+$count = inFlight({ effects: [fx1, fx2] });
+```
+
+- Count all pending runs of effects in one store
+
+### Arguments
+
+1. `effects` _(Array<Effect<any, any, any>>)_ - array of any effects
+
+## Returns
+
+- `$count` _(Store<number>)_ - Store with count of run effects in pending state
+
+## Example
+
+```ts
+import { createEffect } from 'effector';
+import { inFlight } from 'patronum/in-flight';
+
+const loadFirst = createEffect().use(() => Promise.resolve(null));
+const loadSecond = createEffect().use(() => Promise.resolve(2));
+const $count = inFlight({ effects: [loadFirst, loadSecond] });
+
+$count.watch((count) => console.info(`count: ${count}`));
+// => count: 0
+
+loadFirst();
+loadSecond();
+// => count: 2
+
+loadSecond();
+loadSecond();
+// => count: 4
+
+// Wait to resolve all effects
+// => count: 0
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ export { debounce } from './debounce';
 export { debug } from './debug';
 export { delay } from './delay';
 export { every } from './every';
+export { inFlight } from './in-flight';
 export { pending } from './pending';
 export { reshape } from './reshape';
 export { some } from './some';

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports.debounce = require('./debounce').debounce;
 module.exports.debug = require('./debug').debug;
 module.exports.delay = require('./delay').delay;
 module.exports.every = require('./every').every;
+module.exports.inFlight = require('./in-flight').inFlight;
 module.exports.pending = require('./pending').pending;
 module.exports.reshape = require('./reshape').reshape;
 module.exports.some = require('./some').some;

--- a/test-typings/in-flight.ts
+++ b/test-typings/in-flight.ts
@@ -1,0 +1,28 @@
+import { expectType } from 'tsd';
+import {
+  Store,
+  createStore,
+  createEvent,
+  createEffect,
+  createDomain,
+} from 'effector';
+import { inFlight } from '../in-flight';
+
+// Check receive effects
+{
+  const fx1 = createEffect<void, void>();
+  const fx2 = createEffect<number, boolean>();
+  const fx3 = createEffect<string, number>();
+
+  expectType<Store<number>>(inFlight({ effects: [fx1, fx2, fx3] }));
+}
+
+// Fails on invalid units
+{
+  const event = createEvent<void>();
+  const store = createStore<number>(0);
+  const domain = createDomain();
+
+  // @ts-expect-error
+  inFlight({ effects: [event, store, domain] });
+}

--- a/test-typings/in-flight.ts
+++ b/test-typings/in-flight.ts
@@ -26,3 +26,13 @@ import { inFlight } from '../in-flight';
   // @ts-expect-error
   inFlight({ effects: [event, store, domain] });
 }
+
+// Check receive domain
+{
+  const app = createDomain();
+  const fx1 = app.createEffect<void, void>();
+  const fx2 = app.createEffect<number, boolean>();
+  const fx3 = app.createEffect<string, number>();
+
+  expectType<Store<number>>(inFlight({ domain: app }));
+}


### PR DESCRIPTION
```ts
import { createEffect } from 'effector';
import { inFlight } from 'patronum/in-flight';

const loadFirst = createEffect().use(() => Promise.resolve(null));
const loadSecond = createEffect().use(() => Promise.resolve(2));
const $count = inFlight({ effects: [loadFirst, loadSecond] });

$count.watch((count) => console.info(`count: ${count}`));
// => count: 0

loadFirst();
loadSecond();
// => count: 2

loadSecond();
loadSecond();
// => count: 4

// Wait to resolve all effects
// => count: 0
```

---

With domain support:


```ts
import { createDomain } from 'effector';
import { inFlight } from 'patronum/in-flight';

const app = createDomain();
const loadFirst = app.createEffect().use(() => Promise.resolve(null));
const loadSecond = app.createEffect().use(() => Promise.resolve(2));
const $count = inFlight({ domain: app });

$count.watch((count) => console.info(`count: ${count}`));
// => count: 0

loadFirst();
loadSecond();
// => count: 2

loadSecond();
loadSecond();
// => count: 4

// Wait to resolve all effects
// => count: 0
```