### PR TITLE
Cover `combineEvents` method with type tests

### DIFF
--- a/combine-events/index.d.ts
+++ b/combine-events/index.d.ts
@@ -1,7 +1,8 @@
 import { Unit, Store, Event, Effect } from 'effector';
 
 type Tuple<T = unknown> = [T] | T[];
-type Payloads = { [key: string]: any } | Tuple<any>;
+type Shape = Record<string, unknown> | Tuple;
+
 type Events<Result> = {
   [Key in keyof Result]: Event<Result[Key]>;
 };
@@ -20,14 +21,14 @@ type ReturnTarget<Result, Target> = Target extends Store<infer S>
     : Effect<Result, D, F>
   : Unit<Result>;
 
-export function combineEvents<P extends Payloads>(config: {
+export function combineEvents<P extends Shape>(config: {
   events: Events<P>;
   reset?: Unit<any>;
 }): Event<P>;
 
 export function combineEvents<
-  P extends Payloads,
-  T extends Unit<Payloads>
+  P extends Shape,
+  T extends Unit<P extends Tuple ? P : Partial<P>>
 >(config: {
   events: Events<P>;
   target: T;

--- a/combine-events/index.d.ts
+++ b/combine-events/index.d.ts
@@ -1,7 +1,7 @@
 import { Unit, Store, Event, Effect } from 'effector';
 
 type Tuple<T = unknown> = [T] | T[];
-type Results = { [key: string]: any } | Tuple<any>;
+type Payloads = { [key: string]: any } | Tuple<any>;
 type Events<Result> = {
   [Key in keyof Result]: Event<Result[Key]>;
 };
@@ -10,9 +10,9 @@ type ReturnTarget<Result, Target> = Target extends Store<infer S>
   ? S extends Result
     ? Store<S>
     : Store<Result>
-  : Target extends Event<infer E>
-  ? E extends Result
-    ? Event<E>
+  : Target extends Event<infer P>
+  ? P extends Result
+    ? Event<P>
     : Event<Result>
   : Target extends Effect<infer P, infer D, infer F>
   ? P extends Result
@@ -20,16 +20,16 @@ type ReturnTarget<Result, Target> = Target extends Store<infer S>
     : Effect<Result, D, F>
   : Unit<Result>;
 
-export function combineEvents<T extends Results>(config: {
-  events: Events<T>;
+export function combineEvents<P extends Payloads>(config: {
+  events: Events<P>;
   reset?: Unit<any>;
-}): Event<T>;
+}): Event<P>;
 
 export function combineEvents<
-  T extends Results,
-  Target extends Unit<Results>
+  P extends Payloads,
+  T extends Unit<Payloads>
 >(config: {
-  events: Events<T>;
-  target: Target;
+  events: Events<P>;
+  target: T;
   reset?: Unit<any>;
-}): ReturnTarget<T, Target>;
+}): ReturnTarget<P, T>;

--- a/test-typings/combine-events.ts
+++ b/test-typings/combine-events.ts
@@ -1,0 +1,183 @@
+import { expectType } from 'tsd';
+import { Event, createEvent } from 'effector';
+import { combineEvents } from '../combine-events';
+
+// Check simple combine of different events
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+
+  interface Target {
+    foo: string;
+    bar: number;
+    baz: boolean;
+  }
+
+  const target = combineEvents({
+    events: { foo, bar, baz },
+  });
+
+  expectType<Event<Target>>(target);
+
+  // @ts-expect-error
+  const _fail1: Event<{ foo: string; bar: number }> = target;
+
+  // @ts-expect-error
+  const _fail2: Event<{ foo: string; bar: number; baz: number }> = target;
+}
+
+// With object
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+  const bai = createEvent<{ foo: string }>();
+
+  interface Target {
+    foo: string;
+    bar: number;
+    baz: boolean;
+    bai: { foo: string };
+  }
+
+  const target = combineEvents({
+    events: { foo, bar, baz, bai },
+  });
+
+  expectType<Event<Target>>(target);
+
+  // @ts-expect-error
+  const _fail1: Event<{ foo: string; bar: number }> = target;
+
+  // @ts-expect-error
+  const _fail2: Event<{ foo: string; bar: number; baz: number }> = target;
+
+  // @ts-expect-error
+  const _fail2: Event<{
+    foo: string;
+    bar: number;
+    baz: number;
+    bai: { demo: string };
+  }> = target;
+}
+
+// Array combiner
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+
+  type Target = [string, number, boolean];
+
+  const target = combineEvents({
+    events: [foo, bar, baz],
+  });
+
+  expectType<Event<Target>>(target);
+
+  // @ts-expect-error
+  const _fail1: Event<[string, number]> = target;
+
+  // @ts-expect-error
+  const _fail2: Event<[string, number, number]> = target;
+}
+
+// With target event
+
+// Check simple combine of different events
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+
+  const target = createEvent<{
+    foo: string;
+    bar: number;
+    baz: boolean;
+  }>();
+
+  combineEvents({
+    events: { foo, bar, baz },
+    target,
+  });
+
+  combineEvents({
+    events: { foo, bar, baz },
+    target: createEvent<{ foo: string; bar: number }>(),
+  });
+
+  // TODO: should throw // @ts-expect-error
+  combineEvents({
+    events: { foo, bar, baz },
+    target: createEvent<{ foo: string; bar: number; baz: number }>(),
+  });
+}
+
+// With object
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+  const bai = createEvent<{ foo: string }>();
+
+  const target = createEvent<{
+    foo: string;
+    bar: number;
+    baz: boolean;
+    bai: { foo: string };
+  }>();
+
+  combineEvents({
+    events: { foo, bar, baz, bai },
+    target,
+  });
+
+  combineEvents({
+    events: { foo, bar, baz, bai },
+    target: createEvent<{ foo: string; bar: number }>(),
+  });
+
+  // TODO: should throw // @ts-expect-error
+  combineEvents({
+    events: { foo, bar, baz, bai },
+    target: createEvent<{ foo: string; bar: number; baz: number }>(),
+  });
+
+  // TODO: should throw // @ts-expect-error
+  combineEvents({
+    events: { foo, bar, baz, bai },
+    target: createEvent<{
+      foo: string;
+      bar: number;
+      baz: number;
+      bai: { demo: string };
+    }>(),
+  });
+}
+
+// Array combiner
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+
+  const target = createEvent<[string, number, boolean]>();
+
+  combineEvents({
+    events: [foo, bar, baz],
+    target,
+  });
+
+  // TODO: should throw // @ts-expect-error
+  combineEvents({
+    events: [foo, bar, baz],
+    target: createEvent<[string, number, number]>(),
+  });
+
+  // TODO: should throw ? // @ts-expect-error
+  combineEvents({
+    events: [foo, bar, baz],
+    target: createEvent<[string]>(),
+  });
+}

--- a/test-typings/combine-events.ts
+++ b/test-typings/combine-events.ts
@@ -1,5 +1,12 @@
 import { expectType } from 'tsd';
-import { Event, createEvent } from 'effector';
+import {
+  Event,
+  Store,
+  Effect,
+  createEvent,
+  createStore,
+  createEffect,
+} from 'effector';
 import { combineEvents } from '../combine-events';
 
 // Check simple combine of different events
@@ -107,7 +114,7 @@ import { combineEvents } from '../combine-events';
     target: createEvent<{ foo: string; bar: number }>(),
   });
 
-  // TODO: should throw // @ts-expect-error
+  // @ts-expect-error
   combineEvents({
     events: { foo, bar, baz },
     target: createEvent<{ foo: string; bar: number; baz: number }>(),
@@ -138,13 +145,13 @@ import { combineEvents } from '../combine-events';
     target: createEvent<{ foo: string; bar: number }>(),
   });
 
-  // TODO: should throw // @ts-expect-error
+  // @ts-expect-error
   combineEvents({
     events: { foo, bar, baz, bai },
     target: createEvent<{ foo: string; bar: number; baz: number }>(),
   });
 
-  // TODO: should throw // @ts-expect-error
+  // @ts-expect-error
   combineEvents({
     events: { foo, bar, baz, bai },
     target: createEvent<{
@@ -169,15 +176,87 @@ import { combineEvents } from '../combine-events';
     target,
   });
 
-  // TODO: should throw // @ts-expect-error
+  // @ts-expect-error
   combineEvents({
     events: [foo, bar, baz],
     target: createEvent<[string, number, number]>(),
   });
 
-  // TODO: should throw ? // @ts-expect-error
+  // @ts-expect-error
   combineEvents({
     events: [foo, bar, baz],
     target: createEvent<[string]>(),
   });
+}
+
+// Check target Event
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+
+  interface Target {
+    foo: string;
+    bar: number;
+    baz: boolean;
+  }
+
+  const target = createEvent<Target>();
+
+  const event = combineEvents({
+    events: { foo, bar, baz },
+    target,
+  });
+
+  expectType<Event<Target>>(event);
+}
+
+// Check target Store
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+
+  interface Target {
+    foo: string;
+    bar: number;
+    baz: boolean;
+  }
+
+  const target = createStore<Target>({
+    foo: 'string',
+    bar: 1,
+    baz: true,
+  });
+
+  const store = combineEvents({
+    events: { foo, bar, baz },
+    target,
+  });
+
+  expectType<Store<Target>>(store);
+}
+
+// Check target Effect
+{
+  const foo = createEvent<string>();
+  const bar = createEvent<number>();
+  const baz = createEvent<boolean>();
+
+  interface Target {
+    foo: string;
+    bar: number;
+    baz: boolean;
+  }
+
+  const target = createEffect<Target, void>({
+    handler: () => {},
+  });
+
+  const effect = combineEvents({
+    events: { foo, bar, baz },
+    target,
+  });
+
+  expectType<Effect<Target, void>>(effect);
 }


### PR DESCRIPTION
But at now types do not guarantee safety for {target:} property

Relates #22