### PR TITLE
Add `debug` type tests and allow undefined shape in `reshape`

### DIFF
--- a/reshape/index.d.ts
+++ b/reshape/index.d.ts
@@ -2,5 +2,13 @@ import { Store } from 'effector';
 
 export function reshape<Type, Shape extends Record<string, unknown>>(_: {
   source: Store<Type>;
-  shape: { [ShapeKey in keyof Shape]: (value: Type) => Shape[ShapeKey] };
-}): { [ResultKey in keyof Shape]: Store<Shape[ResultKey]> };
+  shape: {
+    [ShapeKey in keyof Shape]: (value: Type) => Shape[ShapeKey];
+  };
+}): {
+  [ResultKey in keyof Shape]: Store<
+    undefined extends Shape[ResultKey]
+      ? Exclude<Shape[ResultKey], void> | null
+      : Shape[ResultKey]
+  >;
+};

--- a/reshape/index.js
+++ b/reshape/index.js
@@ -6,7 +6,11 @@ function reshape(argument) {
 
   for (const key in shape) {
     if (key in shape) {
-      result[key] = source.map(shape[key]);
+      const fn = shape[key];
+      result[key] = source.map((state) => {
+        const result = fn(state);
+        return result === undefined ? null : result;
+      });
     }
   }
 

--- a/reshape/readme.md
+++ b/reshape/readme.md
@@ -11,6 +11,7 @@ result = reshape(source, shape);
 ```
 
 - Call each function in `shape` object with data from `source`, and create store with the same name as key in `shape`
+- If function in `shape` returns `undefined`, the same store will contain `null`, because store cannot contain `undefined`.
 
 > No arguments yet
 

--- a/reshape/reshape.test.ts
+++ b/reshape/reshape.test.ts
@@ -59,3 +59,18 @@ test('reshape ejects values from object', () => {
   expect(shape.name.getState()).toBe('Sergey');
   expect(shape.surname.getState()).toBe('Sova');
 });
+
+test('reshape returns null in shape if fn returned undefined', () => {
+  const $user = createStore<{ first: string; second?: number }>({ first: '' });
+
+  const shape = reshape({
+    source: $user,
+    shape: {
+      first: (user) => user.first,
+      second: (user) => user.second,
+    },
+  });
+
+  expect(shape.first.getState()).toBe('');
+  expect(shape.second.getState()).toBe(null);
+});

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -1,0 +1,25 @@
+import { expectType } from 'tsd';
+import { createEvent, createDomain, createEffect, createStore } from 'effector';
+import { debug } from '../debug';
+
+// Allows each unit of effector
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+  expectType<void>(debug(event, $store, fx, domain));
+}
+
+// Allows single argument
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+
+  debug(event);
+  debug($store);
+  debug(fx);
+  debug(domain);
+}

--- a/test-typings/every.ts
+++ b/test-typings/every.ts
@@ -15,22 +15,26 @@ import { every } from '../every';
 }
 
 // Check types for string enum
-// TODO: fix that
-// {
-//   type Enum = 'a' | 'b' | 'c';
-//   const $a = createStore<Enum>('a');
-//   const $b = createStore<Enum>('c');
-//   const $invalid = createStore('d');
+{
+  type Enum = 'a' | 'b' | 'c';
+  const $a = createStore<Enum>('a');
+  const $b = createStore<Enum>('c');
+  const $invalid = createStore('d');
 
-//   const value: Enum = 'c';
+  const value: Enum = 'c';
 
-//   expectType<Store<boolean>>(every({ predicate: value, stores: [$a, $b] }));
+  expectType<Store<boolean>>(every({ predicate: value, stores: [$a, $b] }));
+  expectType<Store<boolean>>(
+    every({ predicate: (c) => c === 'c', stores: [$a, $b] }),
+  );
 
-//   // @ts-expect-error
-//   every({ predicate: value, stores: [$a, $invalid] });
-//   // @ts-expect-error
-//   every({ predicate: 'demo', stores: [$a, $b] });
-// }
+  // @ts-expect-error
+  every({ predicate: value, stores: [$a, $invalid] });
+  // @ts-expect-error
+  every({ predicate: 'demo', stores: [$a, $b] });
+  // @ts-expect-error
+  every({ predicate: (v) => v === 'demo', stores: [$a, $b] });
+}
 
 // Check function predicate
 {

--- a/test-typings/reshape.ts
+++ b/test-typings/reshape.ts
@@ -1,0 +1,59 @@
+import { expectType } from 'tsd';
+import {
+  Store,
+  Event,
+  Effect,
+  createStore,
+  createEvent,
+  createEffect,
+  createDomain,
+} from 'effector';
+import { reshape } from '../reshape';
+
+// Reshapes store with string
+{
+  const $original = createStore<string>('example');
+  expectType<{
+    length: Store<number>;
+    lowercase: Store<string>;
+    hasSpace: Store<boolean>;
+  }>(
+    reshape({
+      source: $original,
+      shape: {
+        length: (string) => string.length,
+        lowercase: (string) => string.toLowerCase(),
+        hasSpace: (string) => string.includes(' '),
+      },
+    }),
+  );
+}
+
+// Do not allows domain, event and effect
+{
+  const domain = createDomain();
+  const event = createEvent();
+  const effect = createEffect();
+
+  // @ts-expect-error
+  reshape({ source: domain, shape: {} });
+  // @ts-expect-error
+  reshape({ source: event, shape: {} });
+  // @ts-expect-error
+  reshape({ source: effect, shape: {} });
+}
+
+// Allows value | undefined
+{
+  const source = createStore<{ first: string; second?: number }>({ first: '' });
+
+  const shape = reshape({
+    source,
+    shape: {
+      first: (data) => data.first,
+      second: (data) => data.second,
+    },
+  });
+
+  expectType<{ first: Store<string>; second: Store<number | null> }>(shape);
+}

--- a/test-typings/some.ts
+++ b/test-typings/some.ts
@@ -15,22 +15,26 @@ import { some } from '../some';
 }
 
 // Check types for string enum
-// TODO: FIX THAT
-// {
-//   type Enum = 'a' | 'b' | 'c';
-//   const $a = createStore<Enum>('a');
-//   const $b = createStore<Enum>('c');
-//   const $invalid = createStore('d');
+{
+  type Enum = 'a' | 'b' | 'c';
+  const $a = createStore<Enum>('a');
+  const $b = createStore<Enum>('c');
+  const $invalid = createStore('d');
 
-//   const value: Enum = 'c';
+  const value: Enum = 'c';
 
-//   expectType<Store<boolean>>(some({ predicate: value, stores: [$a, $b] }));
+  expectType<Store<boolean>>(some({ predicate: value, stores: [$a, $b] }));
+  expectType<Store<boolean>>(
+    some({ predicate: (b) => b === 'b', stores: [$a, $b] }),
+  );
 
-//   // @ts-expect-error
-//   some({ predicate: value, stores: [$a, $invalid] });
-//   // @ts-expect-error
-//   some({ predicate: 'demo', stores: [$a, $b] });
-// }
+  // @ts-expect-error
+  some({ predicate: value, stores: [$a, $invalid] });
+  // @ts-expect-error
+  some({ predicate: 'demo', stores: [$a, $b] });
+  // @ts-expect-error
+  some({ predicate: (c) => c === 'demo', stores: [$a, $b] });
+}
 
 // Check function predicate
 {


### PR DESCRIPTION
### 1. Allow to return `undefined` from `shape` in `reshape` method:

```ts
const source = createStore<{ last?: string, first: string }>({ first: "hi" })

const { first, last } = reshape({
  source,
  shape: {
    first: (data) => data.first,
    last: (data) => data.last,
  },
})

last.getState() // null
```

### 2. Cover `debug` with type tests