### PR TITLE
Removed support of effector@20

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ import { delay, inFlight } from 'patronum';
 
 ## Migration guide
 
+### v0.110
+
+From `v0.110.0` patronum removed support of effector v20. Now minimum supported version is `v21.4`.
+
+Please, before upgrade review release notes of [`effector v21`](https://github.com/zerobias/effector/releases/tag/effector%4021.0.0).
+
+### v0.100
+
 From `v0.100.0` patronum introduced object arguments form with **BREAKING CHANGES**. Please, review [migration guide](./MIGRATION.md) before upgrade from `v0.14.x` on your project.
 
 ---

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "camel-case": "^4.1.1",
     "commitizen": "4.0.3",
     "cz-conventional-changelog": "3.0.2",
-    "effector": "^21.3.0",
+    "effector": "^21.4.0",
     "eslint": "^7.9.0",
     "globby": "^11.0.0",
     "husky": "3.1.0",
@@ -61,7 +61,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "effector": "^20.7.0 || ^21.0.0"
+    "effector": "^21.4.0"
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3004,10 +3004,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-effector@^21.3.0:
-  version "21.3.0"
-  resolved "https://registry.yarnpkg.com/effector/-/effector-21.3.0.tgz#378a990cd570a9f86c0f14fb29ff912ecfe93f58"
-  integrity sha512-EeiFe43tUDsSvTH06Na4xYG2A7xj9uCGpPsz5D51bl/oTq1AiBMtQiE6u+qgmR+OeR6G2c8vhBBrovPqQCN2yg==
+effector@^21.4.0:
+  version "21.5.0"
+  resolved "https://registry.yarnpkg.com/effector/-/effector-21.5.0.tgz#a574222f9e32a6a4157ce142dda9fafb877b3b9d"
+  integrity sha512-OCmmV0uSFjNCBCnQ/1Nwj7ogY/be6lNuQaTzOEUDo6nuskHvJ0dMSm9EloOJhBAuKZrPt3/14mGZ3afTegvvrA==
 
 electron-to-chromium@^1.3.570:
   version "1.3.570"


### PR DESCRIPTION
**BREAKING CHANGE**: removed support of effector `^20`

Now minimum supported version of effector is `21.4`

Please, before upgrade review release notes of [`effector v21`](https://github.com/zerobias/effector/releases/tag/effector%4021.0.0).

closes #72

