### PR TITLE
Fix debounce timeout and source validation

### DIFF
--- a/debounce/debounce.test.ts
+++ b/debounce/debounce.test.ts
@@ -13,7 +13,7 @@ describe('arguments validation', () => {
   test('domain is not allowed', () => {
     expect(() =>
       debounce({ source: createDomain(), timeout: 10 }),
-    ).toThrowError();
+    ).toThrowError(/cannot be domain/);
   });
 
   test('negative timeout is wrong', () => {

--- a/debounce/debounce.test.ts
+++ b/debounce/debounce.test.ts
@@ -3,6 +3,45 @@ import { createStore, createEvent, createEffect, createDomain } from 'effector';
 import { wait } from '../test-library';
 import { debounce } from '.';
 
+describe('arguments validation', () => {
+  test('event, effect and store is allowed as source', () => {
+    debounce({ source: createStore(0), timeout: 10 });
+    debounce({ source: createEvent(), timeout: 10 });
+    debounce({ source: createEffect(), timeout: 10 });
+  });
+
+  test('domain is not allowed', () => {
+    expect(() =>
+      debounce({ source: createDomain(), timeout: 10 }),
+    ).toThrowError();
+  });
+
+  test('negative timeout is wrong', () => {
+    expect(() => debounce({ source: createEvent(), timeout: -1 })).toThrowError(
+      /must be positive/,
+    );
+  });
+
+  test('zero timeout is allowed', () => {
+    debounce({ source: createEvent(), timeout: 0 });
+  });
+
+  test('NaN timeout is wrong', () => {
+    expect(() =>
+      debounce({ source: createEvent(), timeout: Number.NaN }),
+    ).toThrowError(/must be positive/);
+  });
+
+  test('Infinity timeout is wrong', () => {
+    expect(() =>
+      debounce({ source: createEvent(), timeout: Infinity }),
+    ).toThrowError(/must be positive/);
+    expect(() =>
+      debounce({ source: createEvent(), timeout: -Infinity }),
+    ).toThrowError(/must be positive/);
+  });
+});
+
 describe('triple trigger one wait', () => {
   test('event', async () => {
     const watcher = jest.fn();

--- a/debounce/index.js
+++ b/debounce/index.js
@@ -12,9 +12,11 @@ function debounce(argument) {
     'sid',
   ]);
 
-  if (!is.unit(source)) throw new Error('source must be unit from effector');
+  if (!is.unit(source))
+    throw new TypeError('source must be unit from effector');
+  if (is.domain(source)) throw new TypeError('source cannot be domain');
 
-  if (typeof timeout !== 'number' || timeout < 0)
+  if (typeof timeout !== 'number' || timeout < 0 || !Number.isFinite(timeout))
     throw new Error(
       `timeout must be positive number or zero. Received: "${timeout}"`,
     );

--- a/debounce/index.js
+++ b/debounce/index.js
@@ -13,8 +13,11 @@ function debounce(argument) {
   ]);
 
   if (!is.unit(source)) throw new Error('source must be unit from effector');
+
   if (typeof timeout !== 'number' || timeout < 0)
-    throw new Error('timeout must be positive number or zero');
+    throw new Error(
+      `timeout must be positive number or zero. Received: "${timeout}"`,
+    );
 
   const actualName = name || source.shortName || 'unknown';
 

--- a/library.js
+++ b/library.js
@@ -2,7 +2,7 @@
 
 function readProperties(part, target, properties) {
   properties
-    .filter((name) => Boolean(part[name]))
+    .filter((name) => typeof part[name] !== 'undefined')
     .forEach((name) => {
       target[name] = part[name];
     });


### PR DESCRIPTION
config parser before: ignores falsy values
now: ignores only undefined

closes #128 
