### PR TITLE
test(interval.fork): allows to allSettled

### DIFF
--- a/src/interval/interval.fork.test.ts
+++ b/src/interval/interval.fork.test.ts
@@ -87,12 +87,12 @@ test('does not leaves unresolved timeout effect, if stopped', async () => {
   guard({
     source: $count,
     clock: tick,
-    filter: (c) => c > 9,
+    filter: (c) => c === 6,
     target: stop,
   });
 
   const scope = fork();
   await allSettled(start, { scope });
 
-  expect($count).toEqual(10);
+  expect(scope.getState($count)).toEqual(7);
 });

--- a/src/interval/interval.fork.test.ts
+++ b/src/interval/interval.fork.test.ts
@@ -1,4 +1,4 @@
-import { allSettled, createEvent, fork } from 'effector';
+import { allSettled, createEvent, fork, createStore, guard } from 'effector';
 import { argumentHistory, wait, watch } from '../../test-library';
 import { interval } from '.';
 
@@ -77,4 +77,22 @@ test('concurrent run of interval in different scopes', async () => {
   allSettled(stop, { scope: scopeA });
   expect(scopeA.getState(isRunning)).toBe(false);
   expect(scopeB.getState(isRunning)).toBe(false);
+});
+
+test('does not leaves unresolved timeout effect, if stopped', async () => {
+  const start = createEvent();
+  const stop = createEvent();
+  const { tick } = interval({ timeout: 1, start, stop });
+  const $count = createStore(0).on(tick, (s) => s + 1);
+  guard({
+    source: $count,
+    clock: tick,
+    filter: (c) => c > 9,
+    target: stop,
+  });
+
+  const scope = fork();
+  await allSettled(start, { scope });
+
+  expect($count).toEqual(10);
 });


### PR DESCRIPTION
Current version of interval has issue: once its stopped, promise of last timeoutFx is never resolved -> effect is never finalized -> allSettled never resolved
Can be an issue for tests or SSR apps

Changelog:
- timeoutId and reject of promise are stored in their own stores - additional safety measure, when dealing with multiple scopes
- cleanupFx clears last timeout and also calls reject of last created promise, so timeoutFx always resolved in some way
- added test for the problem at `interval.fork.test.ts`