### PR TITLE
Allow pass `$store` as `predicate` for method `some`, add shorthand form

### DIFF
--- a/src/some/index.ts
+++ b/src/some/index.ts
@@ -1,4 +1,9 @@
-import { combine, Store } from 'effector';
+import { combine, is, Store } from 'effector';
+
+export function some<T>(_: {
+  predicate: Store<T>;
+  stores: Array<Store<T>>;
+}): Store<boolean>;
 
 export function some<T>(_: {
   predicate: (value: T) => boolean;
@@ -11,18 +16,48 @@ export function some<T extends string>(_: {
 }): Store<boolean>;
 
 export function some<T>(_: { predicate: T; stores: Array<Store<T>> }): Store<boolean>;
-export function some<T>({
-  predicate,
-  stores,
-}: {
-  predicate: ((value: T) => boolean) | T;
-  stores: Array<Store<T>>;
-}) {
-  const checker = isFunction(predicate)
-    ? predicate
-    : (value: T) => value === predicate;
 
-  return combine(stores, (values) => values.some(checker));
+export function some<T>(stores: Store<T>[], predicate: Store<T>): Store<boolean>;
+export function some<T>(stores: Store<T>[], predicate: T): Store<boolean>;
+
+export function some<T>(
+  stores: Store<T>[],
+  predicate: (value: T) => boolean,
+): Store<boolean>;
+
+export function some<T>(
+  configOrStores:
+    | {
+        predicate: T | ((value: T) => boolean) | Store<T>;
+        stores: Array<Store<T>>;
+      }
+    | Store<T>[],
+  predicateOrNone?: Store<T> | T | ((value: T) => boolean),
+) {
+  let stores: Store<T>[] = [];
+  let predicate: Store<T> | T | ((value: T) => boolean) = () => false;
+  if (Array.isArray(configOrStores)) {
+    stores = configOrStores;
+    predicate = predicateOrNone!;
+  } else if (Array.isArray(configOrStores.stores)) {
+    stores = configOrStores.stores;
+    predicate = configOrStores.predicate;
+  }
+
+  let checker;
+  if (isFunction(predicate)) {
+    checker = predicate;
+  } else if (is.store(predicate)) {
+    checker = predicate.map((value) => (required: T) => value === required);
+  } else {
+    checker = (value: T) => value === predicate;
+  }
+
+  const $values = combine(stores);
+  // Combine pass simple values as is
+  const $checker = checker as Store<(value: T) => boolean>;
+
+  return combine($checker, $values, (checker, values) => values.some(checker));
 }
 
 function isFunction<T>(value: unknown): value is (value: T) => boolean {

--- a/src/some/readme.md
+++ b/src/some/readme.md
@@ -81,3 +81,59 @@ const $isFormFailed = some({
 
 console.assert(false === $isFormFailed.getState());
 ```
+
+## `some({ predicate: Store, stores })`
+
+### Motivation
+
+This overload compares each store to specific value in store `predicate`.
+It is useful when you write `combine` with `||` very often, for example to create an invalid form flag.
+
+### Formulae
+
+```ts
+$result = some({ predicate: $value, stores });
+```
+
+- `$result` will be `true` if at least one value in `stores` equals value in `$value`, otherwise it will be `false`
+
+### Arguments
+
+1. `predicate` _(`Store<T>`)_ — Store contains value to compare values from `stores` with
+1. `stores` _(`Array<Store<T>>`)_ — List of stores to compare with `value`
+1. type of `value` and `stores` should be the same
+
+### Return
+
+- `$result` _(`Store<boolean>`)_ — `true` if at least one store contains `value`
+
+### Example
+
+```ts
+const $allowToCompare = createStore(true);
+
+const $isPasswordCorrect = createStore(true);
+const $isEmailCorrect = createStore(true);
+
+const $isFormFailed = some({
+  predicate: $allowToCompare,
+  stores: [$isPasswordCorrect, $isEmailCorrect],
+});
+
+console.assert(false === $isFormFailed.getState());
+```
+
+## Shorthands
+
+```ts
+$result = some(stores, value);
+$result = some(stores, (value) => false);
+$result = some(stores, $predicate);
+```
+
+Shorthand have the same rules as the main overrides, just it uses positional arguments instead of object-form.
+
+### Arguments
+
+1. `stores` _(`Array<Store<T>>`)_ — List of stores to compare with predicate in the second argument
+2. `predicate` _(`Store<T> | (value: T) => boolean | T`)_ — Predicate to compare with

--- a/src/some/some.test.ts
+++ b/src/some/some.test.ts
@@ -85,6 +85,134 @@ test('function predicate', () => {
   `);
 });
 
+test('allow predicate to use store', () => {
+  const setSource = createEvent<boolean>();
+  const setPredicate = createEvent<boolean>();
+
+  const $predicate = createStore(false).on(setPredicate, (_, value) => value);
+
+  const $first = createStore(true);
+  const $second = createStore(true).on(setSource, (_, value) => value);
+  const $third = createStore(true);
+
+  const $result = some({ predicate: $predicate, stores: [$first, $second, $third] });
+  expect($result.getState()).toBeFalsy();
+
+  setSource(false);
+  expect($result.getState()).toBeTruthy();
+
+  setPredicate(true);
+  expect($result.getState()).toBeTruthy();
+
+  setSource(true);
+  expect($result.getState()).toBeTruthy();
+});
+
+describe('Shorthand form', () => {
+  test('boolean predicate', () => {
+    const fn = jest.fn();
+    const changeOne = createEvent();
+    const changeAnother = createEvent();
+
+    const $first = createStore(false).on(changeAnother, () => true);
+    const $second = createStore(false).on(changeOne, () => true);
+    const $third = createStore(false).on(changeAnother, () => true);
+
+    const $result = some([$first, $second, $third], true);
+
+    $result.watch(fn);
+    expect(fn).toHaveBeenCalledWith(false);
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      false,
+    ]
+  `);
+
+    changeOne();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      false,
+      true,
+    ]
+  `);
+
+    changeAnother();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      false,
+      true,
+    ]
+  `);
+  });
+
+  test('number predicate', () => {
+    const fn = jest.fn();
+    const change = createEvent();
+
+    const $first = createStore(4);
+    const $second = createStore(2).on(change, () => 4);
+    const $third = createStore(4);
+
+    const $result = some([$first, $second, $third], 2);
+
+    $result.watch(fn);
+    expect(fn).toHaveBeenCalledWith(true);
+
+    change();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      true,
+      false,
+    ]
+  `);
+  });
+
+  test('function predicate', () => {
+    const fn = jest.fn();
+    const change = createEvent();
+
+    const $first = createStore(0);
+    const $second = createStore(0).on(change, () => 5);
+    const $third = createStore(0);
+
+    const $result = some([$first, $second, $third], (value) => value > 0);
+
+    $result.watch(fn);
+    expect(fn).toHaveBeenCalledWith(false);
+
+    change();
+    expect(argumentHistory(fn)).toMatchInlineSnapshot(`
+    Array [
+      false,
+      true,
+    ]
+  `);
+  });
+
+  test('allow predicate to use store', () => {
+    const setSource = createEvent<boolean>();
+    const setPredicate = createEvent<boolean>();
+
+    const $predicate = createStore(false).on(setPredicate, (_, value) => value);
+
+    const $first = createStore(true);
+    const $second = createStore(true).on(setSource, (_, value) => value);
+    const $third = createStore(true);
+
+    const $result = some([$first, $second, $third], $predicate);
+    expect($result.getState()).toBeFalsy();
+
+    setSource(false);
+    expect($result.getState()).toBeTruthy();
+
+    setPredicate(true);
+    expect($result.getState()).toBeTruthy();
+
+    setSource(false);
+    expect($result.getState()).toBeTruthy();
+  });
+});
+
 test('initially true', () => {
   const fn = jest.fn();
 

--- a/src/split-map/split-map.test.ts
+++ b/src/split-map/split-map.test.ts
@@ -53,12 +53,11 @@ test('default case from event', () => {
 });
 
 test('fall through from event', () => {
-  const source =
-    createEvent<{
-      first?: string;
-      second?: boolean;
-      default?: number;
-    }>();
+  const source = createEvent<{
+    first?: string;
+    second?: boolean;
+    default?: number;
+  }>();
   const out = splitMap({
     source,
     cases: {

--- a/test-typings/some.ts
+++ b/test-typings/some.ts
@@ -46,3 +46,51 @@ import { some } from '../src/some';
   // @ts-expect-error
   some({ predicate, stores: [$a, $invalid] });
 }
+
+// Check store predicate
+{
+  const $predicate = createStore(0);
+  const $a = createStore(0);
+  const $b = createStore(1);
+  const $invalid1 = createStore('');
+  const $invalid2 = createStore(true);
+  const $invalid3 = createStore({});
+
+  expectType<Store<boolean>>(some({ predicate: $predicate, stores: [$a, $b] }));
+
+  // @ts-expect-error
+  expectType<Store<boolean>>(some({ predicate: $invalid1, stores: [$a, $b] }));
+
+  // @ts-expect-error
+  expectType<Store<boolean>>(some({ predicate: $invalid2, stores: [$a, $b] }));
+
+  // @ts-expect-error
+  expectType<Store<boolean>>(some({ predicate: $invalid3, stores: [$a, $b] }));
+}
+
+// Shorthands
+{
+  const predicate = (value: number) => value > 0;
+  const $predicate = createStore(0);
+  const $a = createStore(0);
+  const $b = createStore(1);
+  const $invalid1 = createStore('');
+  const $invalid2 = createStore(true);
+  const $invalid3 = createStore({});
+
+  expectType<Store<boolean>>(some([$a, $b], 0));
+  // @ts-expect-error
+  some([$a, $invalid1], 0);
+
+  expectType<Store<boolean>>(some([$a, $b], predicate));
+  // @ts-expect-error
+  some([$a, $invalid1], predicate);
+
+  expectType<Store<boolean>>(some([$a, $b], $predicate));
+  // @ts-expect-error
+  expectType<Store<boolean>>(some([$a, $b], $invalid1));
+  // @ts-expect-error
+  expectType<Store<boolean>>(some([$a, $b], $invalid2));
+  // @ts-expect-error
+  expectType<Store<boolean>>(some([$a, $b], $invalid3));
+}


### PR DESCRIPTION
### Description

Closes #77 
Closes #191 

### Checklist for a new method

- [ ] Create a directory for the new method in the `src` directory in `param-case`
- [x] Place the source code to `src/method-name/index.ts` in ESModules export in `camelCase` **named** export
- [x] Add tests to `src/method-name/method-name.test.ts`
- [x] Add **fork** tests to `src/method-name/method-name.fork.test.ts`
- [x] Add **type** tests to `test-typings/method-name.ts`
  - Use `// @ts-expect-error` to mark expected type error
  - `import { expectType } from 'tsd'` to check expected return type
- [x] Add documentation in `src/method-name/readme.md`
  - Add header `Patronum/MethodName`
  - Add section with overloads, if have
  - Add `Motivation`, `Formulae`, `Arguments` and `Return` sections for each overload
  - Add useful examples in `Example` section for each overload
- [ ] Add section to `README.md` in the repository root
  - Add method to the table of contents into correct category `- [MethodName](#methodname) - description.`
  - Add section `## MethodName`
  - Add `[Method documentation & API](/src/method-name)` into section
  - Add simple example
