### PR TITLE
Fix spread typings

### DIFF
--- a/src/spread/index.ts
+++ b/src/spread/index.ts
@@ -7,7 +7,7 @@ export function spread<Payload>(config: {
   targets: {
     [Key in keyof Payload]?: Unit<Payload[Key]>;
   };
-}): EventAsReturnType<Payload>;
+}): EventAsReturnType<Partial<Payload>>;
 
 export function spread<
   Source,

--- a/test-typings/spread.ts
+++ b/test-typings/spread.ts
@@ -138,7 +138,7 @@ import { spread } from '../src/spread';
 
 // Check target different units without source
 {
-  expectType<Event<{ foo: string; bar: number; baz: boolean }>>(
+  expectType<Event<{ foo?: string; bar?: number; baz?: boolean }>>(
     spread({
       targets: {
         foo: createStore(''),


### PR DESCRIPTION
Spread Readme saying

> If source is triggered with object but without property field, target for this field will not be triggered

So it's expected to have a partial source. Now TS [shows errors with valid code](https://www.typescriptlang.org/play?noUncheckedIndexedAccess=true&allowSyntheticDefaultImports=true&ts=4.5.4#code/JYWwDg9gTgLgBAbwM5igUwIYBMC+cBmUEIcA5GBjEQHYCuIpA3AFCiSyIDG6laAyjGhoANHG6YYaAKIA3NNRiikGcABs0eQsTJp8+NJ0FQmzVgrRR8GTmjgAhVRE4BrRMzge4wLAC44SKmBqAHNmHFNOCGoAuAASACNHFyQ4AF4xHkkBIQAeACUDaCwcgKgg4NEHJ2cAPhqACgQcAEoIqJisNHVJKpc0jIlpOQUchG8-UvKcBtbI6PhE6oARLrRJLH7xXll5GBze2vrW5mU1NEb3fwhaKBs-BKTnJGFLzke-Tu60A5ePfGo-PVFslRGNcM00jU3J4xO14AgANreAC6H1W6x+cAAdDjaGAsLwsAcUnh0sCnqZLh50DAbtREJ81mgiY9RHiCRjHkhwh4cL84DAMFBgmsJqhMFgLjDBcK1kg-AgqZ5GZzqn5ySsvlh+TD2YTifdyc8lXzLi0Xi1mEA)