### PR TITLE
Change modules files extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "cleanup": "rm -rf dist && mkdir dist",
     "build:indexes": "node scripts/build.js",
     "build:types": "tsc --project ./tsconfig.build.json",
-    "build:commonjs": "yarn babel --verbose --out-dir dist src -x .ts --ignore '**/*.test.ts','**/*.d.ts'",
-    "build:mjs": "ESMODULES=true yarn build:commonjs --out-file-extension .mjs",
+    "build:commonjs": "yarn babel --verbose --out-dir dist src -x .ts --ignore '**/*.test.ts','**/*.d.ts' --out-file-extension .cjs",
+    "build:mjs": "ESMODULES=true yarn build:commonjs --out-file-extension .js",
     "build:bundles": "rollup -c",
     "build": "run-s cleanup build:indexes build:types build:commonjs build:mjs build:bundles",
     "prepublishOnly": "yarn build:methods && yarn build:cjs"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,16 +8,16 @@ const plugins = [
   terser({}),
 ];
 
-const input = 'dist/index.js';
+const input = 'dist/index.cjs';
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default [
   {
-    input: 'dist/index.mjs',
+    input: 'dist/index.js',
     external: ['effector'],
     plugins,
     output: {
-      file: './dist/patronum.mjs',
+      file: './dist/patronum.js',
       format: 'es',
       sourcemap: true,
       externalLiveBindings: false,
@@ -28,7 +28,7 @@ export default [
     external: ['effector'],
     plugins,
     output: {
-      file: './dist/patronum.cjs.js',
+      file: './dist/patronum.cjs',
       format: 'cjs',
       freeze: false,
       exports: 'named',

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -32,9 +32,9 @@ async function main() {
   pkg.exports = {
     './package.json': './package.json',
     '.': {
-      require: './index.js',
-      import: './index.mjs',
-      default: './index.mjs',
+      require: './index.cjs',
+      import: './index.js',
+      default: './index.js',
     },
     './babel-preset': {
       require: './babel-preset.cjs',
@@ -47,8 +47,8 @@ async function main() {
 
   const internalPkg = {
     type: 'module',
-    main: 'index.js',
-    module: 'index.mjs',
+    main: 'index.cjs',
+    module: 'index.js',
     types: 'index.d.ts',
   };
 
@@ -58,8 +58,8 @@ async function main() {
     ),
   );
 
-  await directory.write('index.js', createCommonJsIndex(names));
-  await directory.write('index.mjs', createMjsIndex(names));
+  await directory.write('index.cjs', createCommonJsIndex(names));
+  await directory.write('index.js', createMjsIndex(names));
   await directory.write('index.d.ts', createTypingsIndex(names));
   await directory.write('macro.d.ts', 'export * from "./index";');
 

--- a/scripts/libraries.js
+++ b/scripts/libraries.js
@@ -11,7 +11,7 @@ const mkdir = promisify(fs.mkdir);
 function createCommonJsIndex(names) {
   const imports = names.sort().map((name) => {
     const camel = camelCase(name);
-    return `module.exports.${camel} = require('./${name}').${camel};`;
+    return `module.exports.${camel} = require('./${name}/index.cjs').${camel};`;
   });
 
   return imports.join('\n') + '\n';
@@ -20,7 +20,7 @@ function createCommonJsIndex(names) {
 function createMjsIndex(names) {
   const imports = names.sort().map((name) => {
     const camel = camelCase(name);
-    return `export { ${camel} } from './${name}/index.mjs'`;
+    return `export { ${camel} } from './${name}/index.js'`;
   });
 
   return imports.join('\n') + '\n';
@@ -49,8 +49,8 @@ function createExportsMap(names) {
   names.forEach((name) => {
     object[`./${name}/package.json`] = `./${name}/package.json`;
     object[`./${name}`] = {
-      require: `./${name}/index.js`,
-      import: `./${name}/index.mjs`,
+      require: `./${name}/index.cjs`,
+      import: `./${name}/index.js`,
     };
   });
   return object;

--- a/scripts/libraries.test.js
+++ b/scripts/libraries.test.js
@@ -8,9 +8,9 @@ const {
 test('commonjs index with multiple words', () => {
   expect(createCommonJsIndex(['first', 'second-item', 'another-text-demo']))
     .toMatchInlineSnapshot(`
-    "module.exports.anotherTextDemo = require('./another-text-demo').anotherTextDemo;
-    module.exports.first = require('./first').first;
-    module.exports.secondItem = require('./second-item').secondItem;
+    "module.exports.anotherTextDemo = require('./another-text-demo/index.cjs').anotherTextDemo;
+    module.exports.first = require('./first/index.cjs').first;
+    module.exports.secondItem = require('./second-item/index.cjs').secondItem;
     "
   `);
 });

--- a/scripts/source.package.js
+++ b/scripts/source.package.js
@@ -3,9 +3,9 @@ module.exports = () => ({
   version: '0.0.0-real-version-will-be-set-on-ci',
   description: '☄️ Effector utility library delivering modularity and convenience',
   type: 'module',
-  main: 'patronum.cjs.js',
+  main: 'patronum.cjs',
   types: 'index.d.ts',
-  module: 'patronum.mjs',
+  module: 'patronum.js',
   browser: 'patronum.umd.js',
   sideEffects: false,
   repository: {


### PR DESCRIPTION
Change ES modules extensions to `.js`, and Common JS modules extensions to `.cjs`.

In my experience with `effector-storage` package, this should work in any bundler, except FuseBox 3, which latest release was three years ago, and even authors recommended to use FuseBox 4 (https://github.com/fuse-box/fuse-box/issues/1383)

Related issues in `effector-storage` package:
https://github.com/yumauri/effector-storage/issues/12
https://github.com/yumauri/effector-storage/issues/16