### PR TITLE
Add tracing support for `debug`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "camel-case": "^4.1.1",
     "commitizen": "4.0.3",
     "cz-conventional-changelog": "3.0.2",
-    "effector": "22.3.0",
+    "effector": "^22.3.0",
     "eslint": "^7.9.0",
     "globby": "^11.0.0",
     "husky": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "camel-case": "^4.1.1",
     "commitizen": "4.0.3",
     "cz-conventional-changelog": "3.0.2",
-    "effector": "^22.1.1",
+    "effector": "22.3.0",
     "eslint": "^7.9.0",
     "globby": "^11.0.0",
     "husky": "3.1.0",

--- a/src/condition/index.ts
+++ b/src/condition/index.ts
@@ -94,18 +94,18 @@ export function condition<State>({
         then: thenBranch,
         else: elseBranch,
       },
-    });
+    } as any);
   } else if (thenBranch) {
     guard({
       source,
       filter: checker,
-      target: thenBranch,
+      target: thenBranch as Unit<State>,
     });
   } else if (elseBranch) {
     guard({
       source,
       filter: inverse(checker as any),
-      target: elseBranch,
+      target: elseBranch as Unit<State>,
     });
   }
 

--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -1,4 +1,12 @@
-import { createDomain, fork, allSettled } from 'effector';
+import {
+  createDomain,
+  fork,
+  allSettled,
+  createEffect,
+  createEvent,
+  createStore,
+  sample,
+} from 'effector';
 
 import { argumentsHistory } from '../../test-library';
 import { debug } from './index';
@@ -8,14 +16,17 @@ const stringArguments = (ƒ: any) =>
     value.map((a) => (typeof a === 'object' ? JSON.stringify(a) : a)).join(' '),
   );
 
+const originalCollapsed = global.console.groupCollapsed;
 const original = global.console.info;
 let fn: any;
 
 beforeEach(() => {
   global.console.info = fn = jest.fn();
+  global.console.groupCollapsed = fn;
 });
 afterEach(() => {
   global.console.info = original;
+  global.console.groupCollapsed = originalCollapsed;
 });
 
 test('works in forked scope', async () => {
@@ -57,6 +68,74 @@ test('works in forked scope', async () => {
       "[effect] app/effect demo",
       "[effect] app/effect.done {\\"params\\":\\"demo\\",\\"result\\":\\"result demo\\"}",
       "[store] app/$store 500",
+    ]
+  `);
+});
+
+test('trace support', async () => {
+  const buttonClicked = createEvent();
+  const inputChanged = createEvent();
+  const $form = createStore(0).on(inputChanged, (s) => s + 1);
+  const $formValid = $form.map((s) => s > 0);
+  const submitFx = createEffect(() => {});
+
+  $form.on(submitFx.doneData, (s) => s + 1);
+
+  sample({
+    source: $form,
+    clock: buttonClicked,
+    filter: $formValid,
+    target: submitFx,
+  });
+
+  debug({ trace: true }, $form, submitFx);
+
+  expect(stringArguments(fn)).toMatchInlineSnapshot(`
+    Array [
+      "[store] $form 0",
+    ]
+  `);
+
+  const scope = fork();
+
+  await allSettled(inputChanged, { scope });
+
+  expect(stringArguments(fn)).toMatchInlineSnapshot(`
+    Array [
+      "[store] $form 0",
+      "[store] $form 1",
+      "[store] $form trace",
+      "<- [store] $form 1",
+      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [event] inputChanged ",
+    ]
+  `);
+
+  await allSettled(buttonClicked, { scope });
+
+  expect(stringArguments(fn)).toMatchInlineSnapshot(`
+    Array [
+      "[store] $form 0",
+      "[store] $form 1",
+      "[store] $form trace",
+      "<- [store] $form 1",
+      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [event] inputChanged ",
+      "[effect] submitFx 1",
+      "[effect] submitFx trace",
+      "<- [effect] submitFx 1",
+      "<- [sample]  1",
+      "<- [event] buttonClicked ",
+      "[effect] submitFx.done {\\"params\\":1}",
+      "[store] $form 2",
+      "[store] $form trace",
+      "<- [store] $form 2",
+      "<- [$form.on] $form.on(submitFx.doneData) 2",
+      "<- [event] submitFx.doneData ",
+      "<- [map]  ",
+      "<- [event] submitFx.done {\\"params\\":1}",
+      "<- [filterMap]  {\\"params\\":1}",
+      "<- [event] submitFx.finally {\\"status\\":\\"done\\",\\"params\\":1}",
     ]
   `);
 });

--- a/src/debug/debug.test.ts
+++ b/src/debug/debug.test.ts
@@ -4,6 +4,10 @@ import {
   createStore,
   createDomain,
   sample,
+  guard,
+  forward,
+  split,
+  merge,
 } from 'effector';
 import { argumentsHistory } from '../../test-library';
 import { debug } from './index';
@@ -186,6 +190,30 @@ test('trace support', async () => {
       "<- [event] submitFx.done {\\"params\\":1}",
       "<- [filterMap]  {\\"params\\":1}",
       "<- [event] submitFx.finally {\\"status\\":\\"done\\",\\"params\\":1}",
+    ]
+  `);
+});
+
+test('domain is traceable', async () => {
+  const d = createDomain();
+  const up = d.createEvent();
+  const $c = d.createStore(0).on(up, (s) => s + 1);
+
+  debug({ trace: true }, d);
+
+  up();
+
+  expect(stringArguments(fn)).toMatchInlineSnapshot(`
+    Array [
+      "[store] d/$c 0",
+      "[event] d/up ",
+      "[event] d/up trace",
+      "<- [event] up ",
+      "[store] d/$c 1",
+      "[store] d/$c trace",
+      "<- [store] $c 1",
+      "<- [$c.on] $c.on(up) 1",
+      "<- [event] up ",
     ]
   `);
 });

--- a/src/debug/debug.test.ts
+++ b/src/debug/debug.test.ts
@@ -1,4 +1,10 @@
-import { createEvent, createEffect, createStore, createDomain } from 'effector';
+import {
+  createEvent,
+  createEffect,
+  createStore,
+  createDomain,
+  sample,
+} from 'effector';
 import { argumentsHistory } from '../../test-library';
 import { debug } from './index';
 
@@ -7,14 +13,17 @@ const stringArguments = (ƒ: any) =>
     value.map((a) => (typeof a === 'object' ? JSON.stringify(a) : a)).join(' '),
   );
 
+const originalCollapsed = global.console.groupCollapsed;
 const original = global.console.info;
 let fn: any;
 
 beforeEach(() => {
   global.console.info = fn = jest.fn();
+  global.console.groupCollapsed = fn;
 });
 afterEach(() => {
   global.console.info = original;
+  global.console.groupCollapsed = originalCollapsed;
 });
 
 test('debug event, store, effect simultaneously', async () => {
@@ -111,6 +120,72 @@ test('debug domain', async () => {
       "[store] domain/_$store 5",
       "[effect] domain/effect.done {\\"params\\":\\"demo\\",\\"result\\":\\"resultdemo\\"}",
       "[store] domain/_$store 50",
+    ]
+  `);
+});
+
+test('trace support', async () => {
+  const buttonClicked = createEvent();
+  const inputChanged = createEvent();
+  const $form = createStore(0).on(inputChanged, (s) => s + 1);
+  const $formValid = $form.map((s) => s > 0);
+  const submitFx = createEffect(() => {});
+
+  $form.on(submitFx.doneData, (s) => s + 1);
+
+  sample({
+    source: $form,
+    clock: buttonClicked,
+    filter: $formValid,
+    target: submitFx,
+  });
+
+  debug({ trace: true }, $form, submitFx);
+
+  expect(stringArguments(fn)).toMatchInlineSnapshot(`
+    Array [
+      "[store] $form 0",
+    ]
+  `);
+
+  inputChanged();
+
+  expect(stringArguments(fn)).toMatchInlineSnapshot(`
+    Array [
+      "[store] $form 0",
+      "[store] $form 1",
+      "[store] $form trace",
+      "<- [store] $form 1",
+      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [event] inputChanged ",
+    ]
+  `);
+
+  buttonClicked();
+
+  expect(stringArguments(fn)).toMatchInlineSnapshot(`
+    Array [
+      "[store] $form 0",
+      "[store] $form 1",
+      "[store] $form trace",
+      "<- [store] $form 1",
+      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [event] inputChanged ",
+      "[effect] submitFx 1",
+      "[effect] submitFx trace",
+      "<- [effect] submitFx 1",
+      "<- [sample]  1",
+      "<- [event] buttonClicked ",
+      "[effect] submitFx.done {\\"params\\":1}",
+      "[store] $form 2",
+      "[store] $form trace",
+      "<- [store] $form 2",
+      "<- [$form.on] $form.on(submitFx.doneData) 2",
+      "<- [event] submitFx.doneData ",
+      "<- [map]  ",
+      "<- [event] submitFx.done {\\"params\\":1}",
+      "<- [filterMap]  {\\"params\\":1}",
+      "<- [event] submitFx.finally {\\"status\\":\\"done\\",\\"params\\":1}",
     ]
   `);
 });

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,21 +1,45 @@
-import { Domain, Effect, Event, is, Store, Unit } from 'effector';
+import {
+  Stack,
+  Node,
+  Effect,
+  Event,
+  is,
+  Store,
+  Unit,
+  createNode,
+  step,
+} from 'effector';
 
-export function debug(...units: Unit<any>[]): void {
-  for (const unit of units) {
-    const type = getType(unit);
+export function debug(
+  ...units:
+    | Unit<any>[]
+    | [
+        {
+          trace: boolean;
+        },
+        ...Unit<any>[]
+      ]
+): void {
+  let config: { trace: boolean } = { trace: false };
+  const [maybeConfig, ...restUnits] = units;
 
-    if (is.store(unit) || is.effect(unit) || is.event(unit)) {
-      log(unit, type);
+  if (!is.unit(maybeConfig)) {
+    config = maybeConfig;
+  } else {
+    logUnit(maybeConfig);
+
+    if (config.trace) {
+      logTrace(maybeConfig);
     }
+  }
 
-    if (is.effect(unit)) {
-      logEffect(unit);
-    }
+  for (const unit of restUnits) {
+    if (is.unit(unit)) {
+      logUnit(unit);
 
-    if (is.domain(unit)) {
-      unit.onCreateEvent((event) => log(event, 'event'));
-      unit.onCreateStore((store) => log(store, 'store'));
-      unit.onCreateEffect(logEffect);
+      if (config.trace) {
+        logTrace(unit);
+      }
     }
   }
 }
@@ -56,7 +80,13 @@ function logEffect(unit: Effect<any, any, any>) {
   log(unit.fail, 'effect', getName(unit) + '.');
 }
 
-function getName(unit: any) {
+function getNode(node: Node | { graphite: Node }) {
+  const actualNode = 'graphite' in node ? node.graphite : node;
+
+  return actualNode;
+}
+
+function getName(unit: any): string {
   if (unit.compositeName && unit.compositeName.fullName) {
     return unit.compositeName.fullName;
   }
@@ -67,4 +97,114 @@ function getName(unit: any) {
     return unit.name;
   }
   return '';
+}
+
+function readLoc({
+  meta,
+}: Node): void | { file?: string; line: number; column: number } {
+  const loc = 'config' in meta ? meta.config.loc : meta.loc;
+
+  return loc;
+}
+
+function getLoc(unit: Node) {
+  const loc = readLoc(unit);
+
+  if (!loc) return null;
+
+  return `${loc.file ?? ''}:${loc.line}:${loc.column}`;
+}
+
+function logUnit(unit: Unit<any>) {
+  const type = getType(unit);
+
+  if (is.store(unit) || is.effect(unit) || is.event(unit)) {
+    log(unit, type);
+  }
+
+  if (is.effect(unit)) {
+    logEffect(unit);
+  }
+
+  if (is.domain(unit)) {
+    unit.onCreateEvent((event) => log(event, 'event'));
+    unit.onCreateStore((store) => log(store, 'store'));
+    unit.onCreateEffect(logEffect);
+  }
+}
+
+function isEffectChild(node: Node | { graphite: Node }) {
+  const actualNode = getNode(node);
+  const { sid, named } = actualNode.meta;
+
+  return Boolean(
+    !sid &&
+      (named === 'finally' ||
+        named === 'done' ||
+        named === 'doneData' ||
+        named === 'fail' ||
+        named === 'failData' ||
+        named === 'inFlight' ||
+        named === 'pending'),
+  );
+}
+
+function getNodeName(node?: Node) {
+  if (!node) return '';
+
+  const { meta } = node;
+
+  if (!isEffectChild(node)) {
+    return meta.name;
+  }
+
+  const parentEffect = node.family.owners.find((n) => n.meta.op === 'effect');
+
+  if (parentEffect) {
+    return `${getNodeName(parentEffect)}.${meta.named}`;
+  }
+
+  return meta.named;
+}
+
+function logTrace(unit: Unit<any>) {
+  const type = getType(unit);
+  const name = getName(unit);
+
+  createNode({
+    parent: [unit],
+    meta: { op: 'watch' },
+    family: { owners: unit },
+    regional: true,
+    node: [
+      step.run({
+        fn(_data: any, _scope: any, stack: Stack) {
+          let parent = stack?.parent;
+          const groupName = `[${type}] ${name} trace`;
+          // eslint-disable-next-line no-console
+          console.groupCollapsed(groupName);
+          while (parent) {
+            const { node, value } = parent;
+            const { meta } = node;
+            let opName = meta.op;
+            let unitName = getNodeName(node);
+            if (!unitName) {
+              unitName = getLoc(node) ?? '';
+            }
+            if (opName === 'on') {
+              const parentStore = getNodeName(node?.next?.[0]);
+              opName = `${parentStore}.${meta.op}`;
+              unitName = `${parentStore}.${meta.op}(${getNodeName(
+                parent?.parent?.node,
+              )})`;
+            }
+
+            console.info(`<- [${opName}] ${unitName}`, value);
+            parent = parent?.parent;
+          }
+          console.groupEnd();
+        },
+      }),
+    ],
+  });
 }

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -38,3 +38,24 @@ effect('demo');
 // => [effect] effect.done {"params":"demo", "result": "resultdemo"}
 // => [store] $store 60
 ```
+
+## Traces
+
+`patronum/debug` supports computation traces logging, if `{ trace: true }` is set.
+It is recommended to use this feature along with `effector/babel-plugin` and its `addLoc` setting.
+
+```ts
+const inputChanged = createEvent();
+const $form = createStore(0).on(inputChanged, (s) => s + 1);
+
+debug({ trace: true }, $form, submitFx);
+
+inputChanged();
+
+// "[store] $form 0",
+// "[store] $form 1",
+// "[store] $form trace",
+// "<- [store] $form 1",
+// "<- [$form.on] $form.on(inputChanged) 1",
+// "<- [event] inputChanged ",
+```

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -42,7 +42,7 @@ effect('demo');
 ## Traces
 
 `patronum/debug` supports computation traces logging, if `{ trace: true }` is set.
-It is recommended to use this feature along with `effector/babel-plugin` and its `addLoc` setting.
+It is recommended to use this feature along with `effector/babel-plugin`.
 
 ```ts
 const inputChanged = createEvent();

--- a/src/spread/index.ts
+++ b/src/spread/index.ts
@@ -1,5 +1,9 @@
 import { is, createEvent, Event, guard, sample, Unit, Store } from 'effector';
 
+const hasPropBase = {}.hasOwnProperty;
+const hasOwnProp = <O extends { [k: string]: unknown }>(object: O, key: string) =>
+  hasPropBase.call(object, key);
+
 type NoInfer<T> = [T][T extends any ? 0 : never];
 type EventAsReturnType<Payload> = any extends Payload ? Event<Payload> : never;
 
@@ -36,23 +40,25 @@ export function spread<P>({
   source?: Unit<P>;
 }): EventAsReturnType<P> {
   for (const targetKey in targets) {
-    const currentTarget = targets[targetKey];
+    if (hasOwnProp(targets, targetKey)) {
+      const currentTarget = targets[targetKey];
 
-    if (currentTarget) {
-      const hasTargetKey = guard({
-        source,
-        filter: (object): object is any =>
-          typeof object === 'object' && object !== null && targetKey in object,
-      });
-
-      if (is.store(currentTarget)) {
-        currentTarget.on(hasTargetKey, (prev, object) => object[targetKey]);
-      } else {
-        sample({
-          clock: hasTargetKey,
-          fn: (object: P) => object[targetKey],
-          target: currentTarget as Unit<any>,
+      if (currentTarget) {
+        const hasTargetKey = guard({
+          source,
+          filter: (object): object is any =>
+            typeof object === 'object' && object !== null && targetKey in object,
         });
+
+        if (is.store(currentTarget)) {
+          currentTarget.on(hasTargetKey, (prev, object) => object[targetKey]);
+        } else {
+          sample({
+            clock: hasTargetKey,
+            fn: (object: P) => object[targetKey],
+            target: currentTarget as Unit<any>,
+          });
+        }
       }
     }
   }

--- a/src/spread/index.ts
+++ b/src/spread/index.ts
@@ -43,22 +43,20 @@ export function spread<P>({
     if (hasOwnProp(targets, targetKey)) {
       const currentTarget = targets[targetKey];
 
-      if (currentTarget) {
-        const hasTargetKey = guard({
-          source,
-          filter: (object): object is any =>
-            typeof object === 'object' && object !== null && targetKey in object,
-        });
+      const hasTargetKey = guard({
+        source,
+        filter: (object): object is any =>
+          typeof object === 'object' && object !== null && targetKey in object,
+      });
 
-        if (is.store(currentTarget)) {
-          currentTarget.on(hasTargetKey, (prev, object) => object[targetKey]);
-        } else {
-          sample({
-            clock: hasTargetKey,
-            fn: (object: P) => object[targetKey],
-            target: currentTarget as Unit<any>,
-          });
-        }
+      if (is.store(currentTarget)) {
+        currentTarget.on(hasTargetKey, (prev, object) => object[targetKey]);
+      } else {
+        sample({
+          clock: hasTargetKey,
+          fn: (object: P) => object[targetKey],
+          target: currentTarget as Unit<any>,
+        });
       }
     }
   }

--- a/src/spread/index.ts
+++ b/src/spread/index.ts
@@ -45,19 +45,17 @@ export function spread<P>({
 
       const hasTargetKey = guard({
         source,
+        greedy: true,
         filter: (object): object is any =>
           typeof object === 'object' && object !== null && targetKey in object,
       });
 
-      if (is.store(currentTarget)) {
-        currentTarget.on(hasTargetKey, (prev, object) => object[targetKey]);
-      } else {
-        sample({
-          clock: hasTargetKey,
-          fn: (object: P) => object[targetKey],
-          target: currentTarget as Unit<any>,
-        });
-      }
+      sample({
+        greedy: true,
+        clock: hasTargetKey,
+        fn: (object: P) => object[targetKey],
+        target: currentTarget as Unit<any>,
+      });
     }
   }
 

--- a/src/spread/index.ts
+++ b/src/spread/index.ts
@@ -36,23 +36,22 @@ export function spread<P>({
   source?: Unit<P>;
 }): EventAsReturnType<P> {
   for (const targetKey in targets) {
-    if (targetKey in targets) {
+    const currentTarget = targets[targetKey];
+
+    if (currentTarget) {
       const hasTargetKey = guard({
         source,
-        filter: (object) =>
+        filter: (object): object is any =>
           typeof object === 'object' && object !== null && targetKey in object,
       });
 
-      if (is.store(targets[targetKey])) {
-        (targets[targetKey] as Store<any>).on(
-          hasTargetKey,
-          (prev, object) => object[targetKey],
-        );
+      if (is.store(currentTarget)) {
+        currentTarget.on(hasTargetKey, (prev, object) => object[targetKey]);
       } else {
         sample({
-          source: hasTargetKey,
-          fn: (object) => object[targetKey],
-          target: targets[targetKey] as any,
+          clock: hasTargetKey,
+          fn: (object: P) => object[targetKey],
+          target: currentTarget as Unit<any>,
         });
       }
     }

--- a/src/spread/index.ts
+++ b/src/spread/index.ts
@@ -1,4 +1,4 @@
-import { is, createEvent, Event, guard, sample, Unit, Store } from 'effector';
+import { createEvent, Event, guard, sample, Unit } from 'effector';
 
 const hasPropBase = {}.hasOwnProperty;
 const hasOwnProp = <O extends { [k: string]: unknown }>(object: O, key: string) =>
@@ -19,7 +19,9 @@ export function spread<
 >(config: {
   source: Source;
   targets: {
-    [Key in keyof Payload]?: Unit<NoInfer<Payload[Key]>>;
+    [Key in keyof Payload]?:
+      | EventAsReturnType<Partial<Payload[Key]>>
+      | Unit<NoInfer<Payload[Key]>>;
   };
 }): Source;
 

--- a/src/spread/spread.test.ts
+++ b/src/spread/spread.test.ts
@@ -301,7 +301,12 @@ describe('edge', () => {
 
     const fn = jest.fn();
 
-    combine(targetA, targetB, targetC, ([a, b, c]) => [a, b, c]).watch(fn);
+    const final = combine(targetA, targetB, targetC, (a, b, c) => ({
+      first: a,
+      second: b,
+      third: c,
+    }));
+    final.updates.watch(fn);
 
     spread({
       source,
@@ -317,7 +322,12 @@ describe('edge', () => {
       second: 2,
       third: false,
     });
-    expect(fn).toBeCalledTimes(2);
+    expect(final.getState()).toEqual({
+      first: 'foo',
+      second: 2,
+      third: false,
+    });
+    expect(fn).toBeCalledTimes(1);
   });
 });
 

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -23,3 +23,24 @@ import { debug } from '../src/debug';
   debug(fx);
   debug(domain);
 }
+
+// Allows config
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+
+  debug({ trace: true }, event, $store, fx, domain);
+}
+
+// Does not allow config in wrong position
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+
+  // @ts-expect-error
+  debug(event, { trace: true }, $store, fx, domain);
+}

--- a/test-typings/spread.ts
+++ b/test-typings/spread.ts
@@ -192,3 +192,22 @@ import { spread } from '../src/spread';
     },
   });
 }
+
+// allows nested
+{
+  const $source = createStore({ first: '', last: {nested: '', other: ''} });
+  const first = createEvent<string>();
+  const nested = createEvent<string>();
+
+    spread({
+      source: $source,
+      targets: {
+        first,
+        last: spread({
+          targets: {
+            nested,
+          }
+        }),
+      },
+    }),
+}

--- a/test-typings/spread.ts
+++ b/test-typings/spread.ts
@@ -6,6 +6,7 @@ import {
   createStore,
   createEvent,
   createEffect,
+  sample,
 } from 'effector';
 import { spread } from '../src/spread';
 
@@ -227,6 +228,16 @@ import { spread } from '../src/spread';
     },
   });
 
+  // nested wrong match
+  // @ts-expect-error
+  spread({
+    source: $source,
+    targets: {
+      first,
+      last: other,
+    },
+  });
+
   // nested full match outer
   const out = spread({
     targets: {
@@ -256,5 +267,43 @@ import { spread } from '../src/spread';
       first,
       last: outPart,
     },
+  });
+
+  // sample partial match
+  sample({
+    clock: $source,
+    target: spread({
+      targets: {
+        first,
+      },
+    }),
+  });
+
+  // sample full match
+  sample({
+    clock: $source,
+    target: spread({
+      targets: {
+        first,
+        last: spread({
+          targets: {
+            nested,
+            other,
+          },
+        }),
+      },
+    }),
+  });
+
+  // sample wrong match
+  sample({
+    // @ts-expect-error
+    clock: $source,
+    target: spread({
+      targets: {
+        first,
+        last: other,
+      },
+    }),
   });
 }

--- a/test-typings/spread.ts
+++ b/test-typings/spread.ts
@@ -138,15 +138,15 @@ import { spread } from '../src/spread';
 
 // Check target different units without source
 {
-  expectType<Event<{ foo?: string; bar?: number; baz?: boolean }>>(
-    spread({
-      targets: {
-        foo: createStore(''),
-        bar: createEffect<number, void>(),
-        baz: createEvent<boolean>(),
-      },
-    }),
-  );
+  const spreadToStores = spread({
+    targets: {
+      foo: createStore(''),
+      bar: createEffect<number, void>(),
+      baz: createEvent<boolean>(),
+    },
+  });
+
+  expectType<Event<{ foo?: string; bar?: number; baz?: boolean }>>(spreadToStores);
 }
 
 // Example from readme with nullability
@@ -195,19 +195,66 @@ import { spread } from '../src/spread';
 
 // allows nested
 {
-  const $source = createStore({ first: '', last: {nested: '', other: ''} });
+  const $source = createStore({ first: '', last: { nested: '', other: '' } });
   const first = createEvent<string>();
   const nested = createEvent<string>();
+  const other = createEvent<string>();
 
-    spread({
-      source: $source,
-      targets: {
-        first,
-        last: spread({
-          targets: {
-            nested,
-          }
-        }),
-      },
-    }),
+  // nested full match
+  spread({
+    source: $source,
+    targets: {
+      first,
+      last: spread({
+        targets: {
+          nested,
+          other,
+        },
+      }),
+    },
+  });
+
+  // nested partial match
+  spread({
+    source: $source,
+    targets: {
+      first,
+      last: spread({
+        targets: {
+          nested,
+        },
+      }),
+    },
+  });
+
+  // nested full match outer
+  const out = spread({
+    targets: {
+      nested,
+      other,
+    },
+  });
+
+  spread({
+    source: $source,
+    targets: {
+      first,
+      last: out,
+    },
+  });
+
+  // nested partial match outer
+  const outPart = spread({
+    targets: {
+      nested,
+    },
+  });
+
+  spread({
+    source: $source,
+    targets: {
+      first,
+      last: outPart,
+    },
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8303,10 +8303,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"effector@npm:^22.1.1":
-  version: 22.1.1
-  resolution: "effector@npm:22.1.1"
-  checksum: 4c5ed06a6885ead2651a54d26e12cdef3d320651b989c8c5b61ab0da1a5baac93cf99a01f072acf6e6e4314fd6292013383c0a7693a29ec28e74d05d296b4e86
+"effector@npm:22.3.0":
+  version: 22.3.0
+  resolution: "effector@npm:22.3.0"
+  checksum: a220699e03c680fcb13d8e05cd50b7d6ee7ec054b6b18f6ae87edc1b5599debdebe5dbf60e376e2236b5b30872d4d6388d5f02c64406b632d8f65b769538437f
   languageName: node
   linkType: hard
 
@@ -14410,7 +14410,7 @@ __metadata:
     camel-case: ^4.1.1
     commitizen: 4.0.3
     cz-conventional-changelog: 3.0.2
-    effector: ^22.1.1
+    effector: 22.3.0
     eslint: ^7.9.0
     globby: ^11.0.0
     husky: 3.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -8303,7 +8303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"effector@npm:22.3.0":
+"effector@npm:^22.3.0":
   version: 22.3.0
   resolution: "effector@npm:22.3.0"
   checksum: a220699e03c680fcb13d8e05cd50b7d6ee7ec054b6b18f6ae87edc1b5599debdebe5dbf60e376e2236b5b30872d4d6388d5f02c64406b632d8f65b769538437f
@@ -14410,7 +14410,7 @@ __metadata:
     camel-case: ^4.1.1
     commitizen: 4.0.3
     cz-conventional-changelog: 3.0.2
-    effector: 22.3.0
+    effector: ^22.3.0
     eslint: ^7.9.0
     globby: ^11.0.0
     husky: 3.1.0


### PR DESCRIPTION
### Description

<!-- Why we should add this method? -->
Sometimes there is a need for a deeper understanding of why some effect was triggered or store updated.
There is a full info about computation inside effector, so we can just print full computation trace, which happened prior to specific update, using `patronum/debug` with special setting.

### Checklist for a new method

- [x] Create a directory for the new method in the `src` directory in `param-case`
- [x] Place the source code to `src/method-name/index.ts` in ESModules export in `camelCase` **named** export
- [x] Add tests to `src/method-name/method-name.test.ts`
- [x] Add **fork** tests to `src/method-name/method-name.fork.test.ts`
- [x] Add **type** tests to `test-typings/method-name.ts`
  - Use `// @ts-expect-error` to mark expected type error
  - `import { expectType } from 'tsd'` to check expected return type
- [x] Add documentation in `src/method-name/readme.md`
  - Add header `Patronum/MethodName`
  - Add section with overloads, if have
  - Add `Motivation`, `Formulae`, `Arguments` and `Return` sections for each overload
  - Add useful examples in `Example` section for each overload
- [x] Add section to `README.md` in the repository root
  - Add method to the table of contents into correct category `- [MethodName](#methodname) - description.`
  - Add section `## MethodName`
  - Add `[Method documentation & API](/src/method-name)` into section
  - Add simple example
