### PR TITLE
short-circuit evaluation in `and` and `or` operators

### DIFF
--- a/src/and/index.ts
+++ b/src/and/index.ts
@@ -1,10 +1,12 @@
 import { combine, Store } from 'effector';
 
 export function and(...stores: Array<Store<any>>): Store<boolean> {
-  return combine(stores, (values) =>
-    values.reduce(
-      (all, current) => Boolean(all) && Boolean(current),
-      Boolean(values[0]),
-    ),
-  ) as Store<boolean>;
+  return combine(stores, (values) => {
+    for (const value of values) {
+      if (!Boolean(value)) {
+        return false
+      }
+    }
+    return Boolean(values.length) // `false` if zero stores were given
+  }) as Store<boolean>;
 }

--- a/src/or/index.ts
+++ b/src/or/index.ts
@@ -1,10 +1,12 @@
 import { combine, Store } from 'effector';
 
 export function or(...stores: Array<Store<any>>): Store<boolean> {
-  return combine(stores, (values) =>
-    values.reduce(
-      (all, current) => Boolean(all) || Boolean(current),
-      Boolean(values[0]),
-    ),
-  ) as Store<boolean>;
+  return combine(stores, (values) => {
+    for (const value of values) {
+      if (Boolean(value)) {
+        return true
+      }
+    }
+    return false
+  }) as Store<boolean>;
 }


### PR DESCRIPTION
Get rid of `.reduce` in `and` and `or` operators, to achieve short-circuit evaluation