### PR TITLE
Implement detection and print of scopes for `debug`

### DIFF
--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -163,7 +163,6 @@ test('can detect and save unknown scopes', async () => {
   const scopeB = fork();
 
   await allSettled(up, { scope: scopeA });
-  const firstRun = stringArguments(fn);
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     Array [
       "[effect] (scope: unknown_scope_3) fx []",
@@ -182,14 +181,12 @@ test('can detect and save unknown scopes', async () => {
   clearConsole();
 
   await allSettled(up, { scope: scopeA });
-  const secondRun = stringArguments(fn);
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     Array [
       "[effect] (scope: unknown_scope_3) fx []",
       "[effect] (scope: unknown_scope_3) fx.done {\\"params\\":[]}",
     ]
   `);
-  expect(firstRun).toContainEqual(secondRun);
 });
 
 test('can detect registered scopes', async () => {
@@ -222,7 +219,6 @@ test('can detect registered scopes', async () => {
   clearConsole();
 
   await allSettled(up, { scope: scopeA });
-  const firstRun = stringArguments(fn);
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     Array [
       "[effect] (scope: scope_a) fx []",
@@ -241,14 +237,12 @@ test('can detect registered scopes', async () => {
   clearConsole();
 
   await allSettled(up, { scope: scopeA });
-  const secondRun = stringArguments(fn);
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     Array [
       "[effect] (scope: scope_a) fx []",
       "[effect] (scope: scope_a) fx.done {\\"params\\":[]}",
     ]
   `);
-  expect(firstRun).toContainEqual(secondRun);
 });
 
 test('prints default state for store in each of the known scopes', () => {

--- a/src/debug/scope-cache.ts
+++ b/src/debug/scope-cache.ts
@@ -32,4 +32,3 @@ export const scopes = {
   },
 } as const;
 
-export { scopes };

--- a/src/debug/scope-cache.ts
+++ b/src/debug/scope-cache.ts
@@ -1,0 +1,35 @@
+import type { Scope } from 'effector';
+
+interface Meta {
+  name: string;
+}
+
+const cache = new Map<Scope, Meta>();
+
+let unknownScopes = 0;
+function getDefaultName() {
+  unknownScopes += 1;
+  return `unknown_scope_${unknownScopes}`;
+}
+const scopes = {
+  save(scope: Scope, meta?: Meta) {
+    if (!scopes.get(scope)) {
+      cache.set(scope, meta ?? { name: getDefaultName() });
+    }
+  },
+  get(scope?: Scope): Meta | null {
+    if (!scope) return null;
+    return cache.get(scope) ?? null;
+  },
+  delete(scope: Scope) {
+    cache.delete(scope);
+  },
+  forEach(callback: (scope: Scope, meta: Meta) => void) {
+    cache.forEach((meta, scope) => callback(scope, meta));
+  },
+  clear() {
+    cache.clear();
+  },
+} as const;
+
+export { scopes };

--- a/src/debug/scope-cache.ts
+++ b/src/debug/scope-cache.ts
@@ -11,7 +11,7 @@ function getDefaultName() {
   unknownScopes += 1;
   return `unknown_scope_${unknownScopes}`;
 }
-const scopes = {
+export const scopes = {
   save(scope: Scope, meta?: Meta) {
     if (!scopes.get(scope)) {
       cache.set(scope, meta ?? { name: getDefaultName() });


### PR DESCRIPTION
# Changelog

- Added detection of forked scopes and handler to register scope to `debug`