### PR TITLE
Implement custom names for units in `patronum/debug`

### DIFF
--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -428,17 +428,17 @@ test('custom names with traces support', () => {
     Array [
       "[event] (scope: unknown_scope_6) name 1",
       "[event] (scope: unknown_scope_6) name trace",
-      "<- [event] event 1",
+      "<- [event] name 1",
       "[store] (scope: unknown_scope_6) $customName 1",
       "[store] (scope: unknown_scope_6) $customName trace",
-      "<- [store] $store 1",
-      "<- [$store.on] $store.on(event) 1",
-      "<- [event] event 1",
+      "<- [store] $customName 1",
+      "<- [$customName.on] $customName.on(name) 1",
+      "<- [event] name 1",
       "[effect] (scope: unknown_scope_6) nameFx 1",
       "[effect] (scope: unknown_scope_6) nameFx trace",
-      "<- [effect] effect 1",
+      "<- [effect] nameFx 1",
       "<- [sample]  1",
-      "<- [event] event 1",
+      "<- [event] name 1",
     ]
   `);
 });

--- a/src/debug/debug.test.ts
+++ b/src/debug/debug.test.ts
@@ -261,17 +261,17 @@ test('custom names with traces support', () => {
       "[store] $customName 0",
       "[event] name 1",
       "[event] name trace",
-      "<- [event] event 1",
+      "<- [event] name 1",
       "[store] $customName 1",
       "[store] $customName trace",
-      "<- [store] $store 1",
-      "<- [$store.on] $store.on(event) 1",
-      "<- [event] event 1",
+      "<- [store] $customName 1",
+      "<- [$customName.on] $customName.on(name) 1",
+      "<- [event] name 1",
       "[effect] nameFx 1",
       "[effect] nameFx trace",
-      "<- [effect] effect 1",
+      "<- [effect] nameFx 1",
       "<- [sample]  1",
-      "<- [event] event 1",
+      "<- [event] name 1",
     ]
   `);
 });

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -64,6 +64,33 @@ inputChanged();
 // "<- [event] inputChanged ",
 ```
 
+## Custom names
+
+Sometimes unit name in specific context may be different from the one it was initially created with.
+e.g., an unit may be exported under an alias for explicitness:
+
+```ts
+export const $productsListVisible = productsPageModel.$open;
+
+debug($productsListVisible, productAdded);
+// or
+debug({ trace: true }, $productsListVisible, productAdded);
+```
+
+In this case, because of `effector/babel-plugin` which provided `productsPageModel.$open` store its name at the moment of its creation, public name in the `debug` logs will be `$open` instead of `$productsListVisible`.
+
+It can be fixed with custom name, which can be provided by using `Record<string, Unit>` istead of a list of units:
+
+```ts
+export const $productsListVisible = productsPageModel.$open;
+
+debug({ $productsListVisible, customEventName: productAdded });
+// or
+debug({ trace: true }, { $productsListVisible, customEventName: productAdded });
+```
+
+This way `$productsListVisible` name in the logs will be the same, as the one which was provided to `debug`.
+
 ## Fork API and Scope
 
 Effector can run multiple "instances" of the app simultaniosly via Fork API - it is useful for tests and SSR. Usually you would also use scope on the client in the case of SSR. `debug` will log "scoped" updates in such case:
@@ -123,9 +150,8 @@ unregister();
 Or unregister all scopes at once:
 
 ```ts
-debug.unregisterAllScopes()
+debug.unregisterAllScopes();
 ```
-
 
 ### Initial store state
 


### PR DESCRIPTION
# Changelog
- added custom names map support to `debug` for cases, when plugin-provided name is different from desirable

```ts
export const $productsListVisible = productsPageModel.$open;

debug({ $productsListVisible, customEventName: productAdded });
// or
debug({ trace: true }, { $productsListVisible, customEventName: productAdded });

// [event] customEventName 1
// [store] $productsListVisible 1
```
