### PR TITLE
`debug` custom log handler

### DIFF
--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -488,19 +488,19 @@ test('allow custom handlers', async () => {
   expect(argumentsHistory(mockLog)).toMatchInlineSnapshot(`
     [
       [
-        "null.store.$customName.0",
+        "initial.null.store.$customName.0",
       ],
       [
-        "my_scope.store.$customName.0",
+        "initial.my_scope.store.$customName.0",
       ],
       [
-        "my_scope.event.name.1",
+        "update.my_scope.event.name.1",
       ],
       [
         "trace.my_scope.event.name.1",
       ],
       [
-        "my_scope.store.$customName.1",
+        "update.my_scope.store.$customName.1",
       ],
       [
         "trace.my_scope.store.$customName.1",
@@ -512,7 +512,7 @@ test('allow custom handlers', async () => {
         "trace.my_scope.event.name.1",
       ],
       [
-        "my_scope.effect.nameFx.1",
+        "update.my_scope.effect.nameFx.1",
       ],
       [
         "trace.my_scope.effect.nameFx.1",

--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -113,7 +113,7 @@ test('trace support', async () => {
       "[store] (scope: unknown_scope_2) $form 1",
       "[store] (scope: unknown_scope_2) $form trace",
       "<- [store] $form 1",
-      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [on] $form.on(inputChanged) 1",
       "<- [event] inputChanged ",
     ]
   `);
@@ -127,7 +127,7 @@ test('trace support', async () => {
       "[store] (scope: unknown_scope_2) $form 1",
       "[store] (scope: unknown_scope_2) $form trace",
       "<- [store] $form 1",
-      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [on] $form.on(inputChanged) 1",
       "<- [event] inputChanged ",
       "[effect] (scope: unknown_scope_2) submitFx 1",
       "[effect] (scope: unknown_scope_2) submitFx trace",
@@ -138,12 +138,12 @@ test('trace support', async () => {
       "[store] (scope: unknown_scope_2) $form 2",
       "[store] (scope: unknown_scope_2) $form trace",
       "<- [store] $form 2",
-      "<- [$form.on] $form.on(submitFx.doneData) 2",
-      "<- [event] submitFx.doneData ",
+      "<- [on] $form.on(submitFx.doneData) 2",
+      "<- [effect] submitFx.doneData ",
       "<- [map]  ",
-      "<- [event] submitFx.done {"params":1}",
+      "<- [effect] submitFx.done {"params":1}",
       "<- [filterMap]  {"params":1}",
-      "<- [event] submitFx.finally {"status":"done","params":1}",
+      "<- [effect] submitFx.finally {"status":"done","params":1}",
     ]
   `);
 });
@@ -432,7 +432,7 @@ test('custom names with traces support', () => {
       "[store] (scope: unknown_scope_6) $customName 1",
       "[store] (scope: unknown_scope_6) $customName trace",
       "<- [store] $customName 1",
-      "<- [$customName.on] $customName.on(name) 1",
+      "<- [on] $customName.on(name) 1",
       "<- [event] name 1",
       "[effect] (scope: unknown_scope_6) nameFx 1",
       "[effect] (scope: unknown_scope_6) nameFx trace",

--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -471,7 +471,7 @@ test('allow custom handlers', async () => {
           `${context.logType}.${context.scopeName}.${context.kind}.${context.name}.${context.value}`,
         );
 
-        context.trace?.forEach((trace) => {
+        context.trace.forEach((trace) => {
           expect(typeof trace.node).toEqual('object');
           expect(context.scopeName).toEqual('my_scope');
           mockLog(

--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -49,8 +49,8 @@ test('works in forked scope', async () => {
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
       "[store] app/$store 0",
-      "[event] (scope: unknown_scope_1) app/event 5",
-      "[store] (scope: unknown_scope_1) app/$store 5",
+      "[event] (scope: unknown_1) app/event 5",
+      "[store] (scope: unknown_1) app/$store 5",
     ]
   `);
 
@@ -58,9 +58,9 @@ test('works in forked scope', async () => {
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
       "[store] app/$store 0",
-      "[event] (scope: unknown_scope_1) app/event 5",
-      "[store] (scope: unknown_scope_1) app/$store 5",
-      "[effect] (scope: unknown_scope_1) app/effect demo",
+      "[event] (scope: unknown_1) app/event 5",
+      "[store] (scope: unknown_1) app/$store 5",
+      "[effect] (scope: unknown_1) app/effect demo",
     ]
   `);
 
@@ -68,11 +68,11 @@ test('works in forked scope', async () => {
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
       "[store] app/$store 0",
-      "[event] (scope: unknown_scope_1) app/event 5",
-      "[store] (scope: unknown_scope_1) app/$store 5",
-      "[effect] (scope: unknown_scope_1) app/effect demo",
-      "[effect] (scope: unknown_scope_1) app/effect.done {"params":"demo","result":"result demo"}",
-      "[store] (scope: unknown_scope_1) app/$store 500",
+      "[event] (scope: unknown_1) app/event 5",
+      "[store] (scope: unknown_1) app/$store 5",
+      "[effect] (scope: unknown_1) app/effect demo",
+      "[effect] (scope: unknown_1) app/effect.done {"params":"demo","result":"result demo"}",
+      "[store] (scope: unknown_1) app/$store 500",
     ]
   `);
 });
@@ -98,7 +98,7 @@ test('trace support', async () => {
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
       "[store] $form 0",
-      "[store] (scope: unknown_scope_1) $form 0",
+      "[store] (scope: unknown_1) $form 0",
     ]
   `);
 
@@ -109,9 +109,9 @@ test('trace support', async () => {
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
       "[store] $form 0",
-      "[store] (scope: unknown_scope_1) $form 0",
-      "[store] (scope: unknown_scope_2) $form 1",
-      "[store] (scope: unknown_scope_2) $form trace",
+      "[store] (scope: unknown_1) $form 0",
+      "[store] (scope: unknown_2) $form 1",
+      "[store] (scope: unknown_2) $form trace",
       "<- [store] $form 1",
       "<- [on] $form.on(inputChanged) 1",
       "<- [event] inputChanged ",
@@ -123,20 +123,20 @@ test('trace support', async () => {
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
       "[store] $form 0",
-      "[store] (scope: unknown_scope_1) $form 0",
-      "[store] (scope: unknown_scope_2) $form 1",
-      "[store] (scope: unknown_scope_2) $form trace",
+      "[store] (scope: unknown_1) $form 0",
+      "[store] (scope: unknown_2) $form 1",
+      "[store] (scope: unknown_2) $form trace",
       "<- [store] $form 1",
       "<- [on] $form.on(inputChanged) 1",
       "<- [event] inputChanged ",
-      "[effect] (scope: unknown_scope_2) submitFx 1",
-      "[effect] (scope: unknown_scope_2) submitFx trace",
+      "[effect] (scope: unknown_2) submitFx 1",
+      "[effect] (scope: unknown_2) submitFx trace",
       "<- [effect] submitFx 1",
       "<- [sample]  1",
       "<- [event] buttonClicked ",
-      "[effect] (scope: unknown_scope_2) submitFx.done {"params":1}",
-      "[store] (scope: unknown_scope_2) $form 2",
-      "[store] (scope: unknown_scope_2) $form trace",
+      "[effect] (scope: unknown_2) submitFx.done {"params":1}",
+      "[store] (scope: unknown_2) $form 2",
+      "[store] (scope: unknown_2) $form trace",
       "<- [store] $form 2",
       "<- [on] $form.on(submitFx.doneData) 2",
       "<- [effect] submitFx.doneData ",
@@ -165,8 +165,8 @@ test('can detect and save unknown scopes', async () => {
   await allSettled(up, { scope: scopeA });
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[effect] (scope: unknown_scope_3) fx []",
-      "[effect] (scope: unknown_scope_3) fx.done {"params":[]}",
+      "[effect] (scope: unknown_3) fx []",
+      "[effect] (scope: unknown_3) fx.done {"params":[]}",
     ]
   `);
   clearConsole();
@@ -174,8 +174,8 @@ test('can detect and save unknown scopes', async () => {
   await allSettled(up, { scope: scopeB });
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[effect] (scope: unknown_scope_4) fx []",
-      "[effect] (scope: unknown_scope_4) fx.done {"params":[]}",
+      "[effect] (scope: unknown_4) fx []",
+      "[effect] (scope: unknown_4) fx.done {"params":[]}",
     ]
   `);
   clearConsole();
@@ -183,8 +183,8 @@ test('can detect and save unknown scopes', async () => {
   await allSettled(up, { scope: scopeA });
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[effect] (scope: unknown_scope_3) fx []",
-      "[effect] (scope: unknown_scope_3) fx.done {"params":[]}",
+      "[effect] (scope: unknown_3) fx []",
+      "[effect] (scope: unknown_3) fx.done {"params":[]}",
     ]
   `);
 });
@@ -399,9 +399,9 @@ test('custom names basic support', () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[event] (scope: unknown_scope_5) name 1",
-      "[store] (scope: unknown_scope_5) $customName 1",
-      "[effect] (scope: unknown_scope_5) nameFx 1",
+      "[event] (scope: unknown_5) name 1",
+      "[store] (scope: unknown_5) $customName 1",
+      "[effect] (scope: unknown_5) nameFx 1",
     ]
   `);
 });
@@ -426,16 +426,16 @@ test('custom names with traces support', () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[event] (scope: unknown_scope_6) name 1",
-      "[event] (scope: unknown_scope_6) name trace",
+      "[event] (scope: unknown_6) name 1",
+      "[event] (scope: unknown_6) name trace",
       "<- [event] name 1",
-      "[store] (scope: unknown_scope_6) $customName 1",
-      "[store] (scope: unknown_scope_6) $customName trace",
+      "[store] (scope: unknown_6) $customName 1",
+      "[store] (scope: unknown_6) $customName trace",
       "<- [store] $customName 1",
       "<- [on] $customName.on(name) 1",
       "<- [event] name 1",
-      "[effect] (scope: unknown_scope_6) nameFx 1",
-      "[effect] (scope: unknown_scope_6) nameFx trace",
+      "[effect] (scope: unknown_6) nameFx 1",
+      "[effect] (scope: unknown_6) nameFx trace",
       "<- [effect] nameFx 1",
       "<- [sample]  1",
       "<- [event] name 1",

--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -468,7 +468,7 @@ test('allow custom handlers', async () => {
         expect(typeof context.scope).toEqual('object');
 
         mockLog(
-          `${context.scopeName}.${context.kind}.${context.name}.${context.value}`,
+          `${context.logType}.${context.scopeName}.${context.kind}.${context.name}.${context.value}`,
         );
 
         context.trace?.forEach((trace) => {

--- a/src/debug/debug.fork.test.ts
+++ b/src/debug/debug.fork.test.ts
@@ -48,7 +48,7 @@ test('works in forked scope', async () => {
   await allSettled(event, { scope, params: 5 });
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] app/$store 0",
+      "[store] app/$store [getState] 0",
       "[event] (scope: unknown_1) app/event 5",
       "[store] (scope: unknown_1) app/$store 5",
     ]
@@ -57,7 +57,7 @@ test('works in forked scope', async () => {
   allSettled(effect, { scope, params: 'demo' });
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] app/$store 0",
+      "[store] app/$store [getState] 0",
       "[event] (scope: unknown_1) app/event 5",
       "[store] (scope: unknown_1) app/$store 5",
       "[effect] (scope: unknown_1) app/effect demo",
@@ -67,7 +67,7 @@ test('works in forked scope', async () => {
   await 1;
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] app/$store 0",
+      "[store] app/$store [getState] 0",
       "[event] (scope: unknown_1) app/event 5",
       "[store] (scope: unknown_1) app/$store 5",
       "[effect] (scope: unknown_1) app/effect demo",
@@ -97,8 +97,8 @@ test('trace support', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $form 0",
-      "[store] (scope: unknown_1) $form 0",
+      "[store] $form [getState] 0",
+      "[store] (scope: unknown_1) $form [getState] 0",
     ]
   `);
 
@@ -108,8 +108,8 @@ test('trace support', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $form 0",
-      "[store] (scope: unknown_1) $form 0",
+      "[store] $form [getState] 0",
+      "[store] (scope: unknown_1) $form [getState] 0",
       "[store] (scope: unknown_2) $form 1",
       "[store] (scope: unknown_2) $form trace",
       "<- [store] $form 1",
@@ -122,8 +122,8 @@ test('trace support', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $form 0",
-      "[store] (scope: unknown_1) $form 0",
+      "[store] $form [getState] 0",
+      "[store] (scope: unknown_1) $form [getState] 0",
       "[store] (scope: unknown_2) $form 1",
       "[store] (scope: unknown_2) $form trace",
       "<- [store] $form 1",
@@ -209,10 +209,10 @@ test('can detect registered scopes', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] (scope: scope_a) app/$store 0",
-      "[store] (scope: scope_a) $form 0",
-      "[store] (scope: scope_b) app/$store 0",
-      "[store] (scope: scope_b) $form 0",
+      "[store] (scope: scope_a) app/$store [getState] 0",
+      "[store] (scope: scope_a) $form [getState] 0",
+      "[store] (scope: scope_b) app/$store [getState] 0",
+      "[store] (scope: scope_b) $form [getState] 0",
     ]
   `);
 
@@ -263,13 +263,13 @@ test('prints default state for store in each of the known scopes', () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] (scope: scope_42) app/$store 0",
-      "[store] (scope: scope_42) $form 0",
-      "[store] (scope: scope_1337) app/$store 0",
-      "[store] (scope: scope_1337) $form 0",
-      "[store] $count 0",
-      "[store] (scope: scope_42) $count 42",
-      "[store] (scope: scope_1337) $count 1337",
+      "[store] (scope: scope_42) app/$store [getState] 0",
+      "[store] (scope: scope_42) $form [getState] 0",
+      "[store] (scope: scope_1337) app/$store [getState] 0",
+      "[store] (scope: scope_1337) $form [getState] 0",
+      "[store] $count [getState] 0",
+      "[store] (scope: scope_42) $count [getState] 42",
+      "[store] (scope: scope_1337) $count [getState] 1337",
     ]
   `);
 });
@@ -293,14 +293,14 @@ test('individual scope can be unregistered', () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] (scope: scope_42) app/$store 0",
-      "[store] (scope: scope_42) $form 0",
-      "[store] (scope: scope_42) $count 0",
-      "[store] (scope: scope_1337) app/$store 0",
-      "[store] (scope: scope_1337) $form 0",
-      "[store] (scope: scope_1337) $count 0",
-      "[store] $count 0",
-      "[store] (scope: scope_1337) $count 1337",
+      "[store] (scope: scope_42) app/$store [getState] 0",
+      "[store] (scope: scope_42) $form [getState] 0",
+      "[store] (scope: scope_42) $count [getState] 0",
+      "[store] (scope: scope_1337) app/$store [getState] 0",
+      "[store] (scope: scope_1337) $form [getState] 0",
+      "[store] (scope: scope_1337) $count [getState] 0",
+      "[store] $count [getState] 0",
+      "[store] (scope: scope_1337) $count [getState] 1337",
     ]
   `);
 });
@@ -330,10 +330,10 @@ test('traces have scope name', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] (scope: my_scope) app/$store 0",
-      "[store] (scope: my_scope) $form 0",
-      "[store] (scope: my_scope) $count 0",
-      "[store] (scope: my_scope) $count 0",
+      "[store] (scope: my_scope) app/$store [getState] 0",
+      "[store] (scope: my_scope) $form [getState] 0",
+      "[store] (scope: my_scope) $count [getState] 0",
+      "[store] (scope: my_scope) $count [getState] 0",
       "[effect] (scope: my_scope) submitFx 1",
       "[effect] (scope: my_scope) submitFx trace",
       "<- [effect] submitFx 1",
@@ -362,19 +362,19 @@ test('logs stores for newly registered scope', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $count 0",
-      "[store] (scope: scope_1337) $count 0",
-      "[store] (scope: my_scope) $count 0",
-      "[store] (scope: scope_42) app/$store 0",
-      "[store] (scope: scope_42) $form 0",
-      "[store] (scope: scope_42) $count 0",
-      "[store] (scope: scope_42) $count 0",
-      "[store] (scope: scope_42) $count 42",
-      "[store] (scope: scope_1337) app/$store 0",
-      "[store] (scope: scope_1337) $form 0",
-      "[store] (scope: scope_1337) $count 0",
-      "[store] (scope: scope_1337) $count 0",
-      "[store] (scope: scope_1337) $count 1337",
+      "[store] $count [getState] 0",
+      "[store] (scope: scope_1337) $count [getState] 0",
+      "[store] (scope: my_scope) $count [getState] 0",
+      "[store] (scope: scope_42) app/$store [getState] 0",
+      "[store] (scope: scope_42) $form [getState] 0",
+      "[store] (scope: scope_42) $count [getState] 0",
+      "[store] (scope: scope_42) $count [getState] 0",
+      "[store] (scope: scope_42) $count [getState] 42",
+      "[store] (scope: scope_1337) app/$store [getState] 0",
+      "[store] (scope: scope_1337) $form [getState] 0",
+      "[store] (scope: scope_1337) $count [getState] 0",
+      "[store] (scope: scope_1337) $count [getState] 0",
+      "[store] (scope: scope_1337) $count [getState] 1337",
     ]
   `);
 });

--- a/src/debug/debug.test.ts
+++ b/src/debug/debug.test.ts
@@ -41,14 +41,14 @@ test('debug event, store, effect simultaneously', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $store 0",
+      "[store] $store [getState] 0",
     ]
   `);
 
   event(5);
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $store 0",
+      "[store] $store [getState] 0",
       "[event] event 5",
       "[store] $store 5",
     ]
@@ -57,7 +57,7 @@ test('debug event, store, effect simultaneously', async () => {
   effect('demo');
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $store 0",
+      "[store] $store [getState] 0",
       "[event] event 5",
       "[store] $store 5",
       "[effect] effect demo",
@@ -68,7 +68,7 @@ test('debug event, store, effect simultaneously', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $store 0",
+      "[store] $store [getState] 0",
       "[event] event 5",
       "[store] $store 5",
       "[effect] effect demo",
@@ -93,14 +93,14 @@ test('debug domain', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] domain/_$store 0",
+      "[store] domain/_$store [getState] 0",
     ]
   `);
 
   event(5);
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] domain/_$store 0",
+      "[store] domain/_$store [getState] 0",
       "[event] domain/event 5",
       "[store] domain/_$store 5",
     ]
@@ -109,7 +109,7 @@ test('debug domain', async () => {
   effect('demo');
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] domain/_$store 0",
+      "[store] domain/_$store [getState] 0",
       "[event] domain/event 5",
       "[store] domain/_$store 5",
       "[effect] domain/effect demo",
@@ -120,7 +120,7 @@ test('debug domain', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] domain/_$store 0",
+      "[store] domain/_$store [getState] 0",
       "[event] domain/event 5",
       "[store] domain/_$store 5",
       "[effect] domain/effect demo",
@@ -150,7 +150,7 @@ test('trace support', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $form 0",
+      "[store] $form [getState] 0",
     ]
   `);
 
@@ -158,7 +158,7 @@ test('trace support', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $form 0",
+      "[store] $form [getState] 0",
       "[store] $form 1",
       "[store] $form trace",
       "<- [store] $form 1",
@@ -171,7 +171,7 @@ test('trace support', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $form 0",
+      "[store] $form [getState] 0",
       "[store] $form 1",
       "[store] $form trace",
       "<- [store] $form 1",
@@ -213,7 +213,7 @@ test('domain is traceable', async () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] d/$c 0",
+      "[store] d/$c [getState] 0",
       "[event] d/up ",
       "[event] d/up trace",
       "<- [event] up ",
@@ -250,7 +250,7 @@ test('custom names basic support', () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $customName 0",
+      "[store] $customName [getState] 0",
       "[event] name 1",
       "[store] $customName 1",
       "[effect] nameFx 1",
@@ -274,7 +274,7 @@ test('custom names with traces support', () => {
 
   expect(stringArguments(fn)).toMatchInlineSnapshot(`
     [
-      "[store] $customName 0",
+      "[store] $customName [getState] 0",
       "[event] name 1",
       "[event] name trace",
       "<- [event] name 1",

--- a/src/debug/debug.test.ts
+++ b/src/debug/debug.test.ts
@@ -162,7 +162,7 @@ test('trace support', async () => {
       "[store] $form 1",
       "[store] $form trace",
       "<- [store] $form 1",
-      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [on] $form.on(inputChanged) 1",
       "<- [event] inputChanged ",
     ]
   `);
@@ -175,7 +175,7 @@ test('trace support', async () => {
       "[store] $form 1",
       "[store] $form trace",
       "<- [store] $form 1",
-      "<- [$form.on] $form.on(inputChanged) 1",
+      "<- [on] $form.on(inputChanged) 1",
       "<- [event] inputChanged ",
       "[effect] submitFx 1",
       "[effect] submitFx trace",
@@ -186,12 +186,12 @@ test('trace support', async () => {
       "[store] $form 2",
       "[store] $form trace",
       "<- [store] $form 2",
-      "<- [$form.on] $form.on(submitFx.doneData) 2",
-      "<- [event] submitFx.doneData ",
+      "<- [on] $form.on(submitFx.doneData) 2",
+      "<- [effect] submitFx.doneData ",
       "<- [map]  ",
-      "<- [event] submitFx.done {"params":1}",
+      "<- [effect] submitFx.done {"params":1}",
       "<- [filterMap]  {"params":1}",
-      "<- [event] submitFx.finally {"status":"done","params":1}",
+      "<- [effect] submitFx.finally {"status":"done","params":1}",
     ]
   `);
 });
@@ -204,8 +204,8 @@ test('domain is traceable', async () => {
 
   sample({
     clock: $c,
-    target: fx
-  })
+    target: fx,
+  });
 
   debug({ trace: true }, d);
 
@@ -220,14 +220,14 @@ test('domain is traceable', async () => {
       "[store] d/$c 1",
       "[store] d/$c trace",
       "<- [store] $c 1",
-      "<- [$c.on] $c.on(up) 1",
+      "<- [on] $c.on(up) 1",
       "<- [event] up ",
       "[effect] d/fx 1",
       "[effect] d/fx trace",
       "<- [effect] fx 1",
       "<- [sample]  1",
       "<- [store] $c 1",
-      "<- [$c.on] $c.on(up) 1",
+      "<- [on] $c.on(up) 1",
       "<- [event] up ",
       "[effect] d/fx.done {"params":1}",
     ]
@@ -281,7 +281,7 @@ test('custom names with traces support', () => {
       "[store] $customName 1",
       "[store] $customName trace",
       "<- [store] $customName 1",
-      "<- [$customName.on] $customName.on(name) 1",
+      "<- [on] $customName.on(name) 1",
       "<- [event] name 1",
       "[effect] nameFx 1",
       "[effect] nameFx trace",

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -333,7 +333,6 @@ function getScopeName(scope: Scope | null) {
 }
 
 // Utils
-
 function isEffectChild(node: Node | Unit<any>) {
   const actualNode = getNode(node);
   const { sid, named } = actualNode.meta;
@@ -348,6 +347,15 @@ function isEffectChild(node: Node | Unit<any>) {
         named === 'inFlight' ||
         named === 'pending'),
   );
+}
+
+function isStoreOn(node: Node | Unit<any>) {
+  const actualNode = getNode(node);
+  const { op } = actualNode.meta;
+
+  if (op === 'on') return true;
+
+  return false;
 }
 
 function getType(unit: Unit<any> | Node) {
@@ -397,6 +405,14 @@ function getName(unit: Node | Unit<any>): string {
     }
 
     return node.meta.named;
+  }
+
+  if (isStoreOn(unit)) {
+    const node = getNode(unit);
+    const targetStoreName = getName(node.next[0]);
+    const triggerEventName = getName(node.family.owners[0]);
+
+    return `${targetStoreName}.on(${triggerEventName})`;
   }
 
   if (is.unit(unit)) {

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -323,7 +323,7 @@ const cache = new Map<Scope, Meta>();
 let unknownScopes = 0;
 function getDefaultName() {
   unknownScopes += 1;
-  return `unknown_scope_${unknownScopes}`;
+  return `unknown_${unknownScopes}`;
 }
 const scopes = {
   save(scope: Scope, meta?: Meta) {

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -11,33 +11,20 @@ import {
   Scope,
 } from 'effector';
 
-type LogContext =
-  | {
-      type: 'log';
-      /** common */
-      scope: Scope | null;
-      scopeName: string | null;
-      node: Node;
-      value: unknown;
-      name: string;
-      /** trace only */
-      trace?: never;
-    }
-  | {
-      type: 'trace';
-      /** common */
-      scope: Scope | null;
-      scopeName: string | null;
-      node: Node;
-      value: unknown;
-      name: string;
-      /** trace only */
-      trace: {
-        node: Node;
-        name: string;
-        value: unknown;
-      }[];
-    };
+type LogContext = {
+  /** common */
+  scope: Scope | null;
+  scopeName: string | null;
+  node: Node;
+  value: unknown;
+  name: string;
+  /** trace only */
+  trace?: {
+    node: Node;
+    name: string;
+    value: unknown;
+  }[];
+};
 
 interface Config {
   trace?: boolean;

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -12,13 +12,12 @@ import {
 } from 'effector';
 
 type LogContext = {
-  /** common */
   scope: Scope | null;
   scopeName: string | null;
   node: Node;
+  kind: string;
   value: unknown;
   name: string;
-  /** trace only */
   trace?: {
     node: Node;
     name: string;

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -27,7 +27,7 @@ type LogContext = {
     line: number;
     column: number;
   };
-  trace?: {
+  trace: {
     node: Node;
     name: string | null;
     kind: string;
@@ -49,7 +49,8 @@ const defaultConfig: Config = {
   trace: false,
   // default logger to console.info
   handler: (context) => {
-    const { scope, scopeName, name, kind, value, loc, trace, node, logType } = context;
+    const { scope, scopeName, name, kind, value, loc, trace, node, logType } =
+      context;
     const scopeLog = scope ? ` (scope: ${scopeName})` : '';
 
     const logName = name ?? (loc ? `${loc.file}:${loc.line}:${loc.column}` : '');
@@ -155,7 +156,7 @@ function watch(unit: Unit<any>, config: Config) {
             value,
             name: getName(unit),
             loc: getLoc(unit),
-            trace: config.trace ? collectTrace(stack) : undefined,
+            trace: config.trace ? collectTrace(stack) : [],
           };
 
           if (!config.handler) {
@@ -215,7 +216,8 @@ function watchStoreInit(store: Store<any>, config: Config) {
     value: store.getState(),
     name: getName(store),
     loc: getLoc(store),
-    trace: config.trace ? [] : undefined,
+    // nothing to trace for store.getState() - it is one-step call
+    trace: [],
   };
 
   config.handler(context);
@@ -243,7 +245,8 @@ function watchStoreInitInScope(store: Store<any>, config: Config, scope: Scope) 
     value: scope.getState(store),
     name: getName(store),
     loc: getLoc(store),
-    trace: config.trace ? [] : undefined,
+    // nothing to trace for scope.getState(store) - it is one-step call
+    trace: [],
   };
 
   config.handler(context);

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -14,6 +14,7 @@ import {
 type LogContext = {
   scope: Scope | null;
   scopeName: string | null;
+  /** node, kind, value, name - common fields for logs and traces */
   node: Node;
   kind: string;
   value: unknown;
@@ -21,6 +22,7 @@ type LogContext = {
   trace?: {
     node: Node;
     name: string;
+    kind: string;
     value: unknown;
   }[];
 };

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -49,12 +49,13 @@ const defaultConfig: Config = {
   trace: false,
   // default logger to console.info
   handler: (context) => {
-    const { scope, scopeName, name, kind, value, loc, trace, node } = context;
+    const { scope, scopeName, name, kind, value, loc, trace, node, logType } = context;
     const scopeLog = scope ? ` (scope: ${scopeName})` : '';
 
     const logName = name ?? (loc ? `${loc.file}:${loc.line}:${loc.column}` : '');
+    const logPrintType = logType === 'initial' ? ' [getState]' : '';
 
-    console.info(`[${kind}]${scopeLog} ${logName}`, value);
+    console.info(`[${kind}]${scopeLog} ${logName}${logPrintType}`, value);
 
     if (
       // logging trace only if there is something to log

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -428,7 +428,12 @@ function getName(unit: Node | Unit<any>): string | null {
     const parentEffect = node.family.owners.find((n) => n.meta.op === 'effect');
 
     if (parentEffect) {
-      return `${getName(parentEffect)}.${node.meta.named}`;
+      const closestParentDomainName = getOwningDomainName(parentEffect);
+      const formattedDomainName = closestParentDomainName
+        ? `${closestParentDomainName}/`
+        : '';
+
+      return `${formattedDomainName}${getName(parentEffect)}.${node.meta.named}`;
     }
 
     return node.meta.named;
@@ -446,11 +451,17 @@ function getName(unit: Node | Unit<any>): string | null {
     if ((unit as any)?.compositeName?.fullName) {
       return (unit as any).compositeName.fullName;
     }
+
+    const closestParentDomainName = getOwningDomainName(unit);
+    const formattedDomainName = closestParentDomainName
+      ? `${closestParentDomainName}/`
+      : '';
+
     if ((unit as any)?.shortName) {
-      return (unit as any).shortName;
+      return `${formattedDomainName}${(unit as any).shortName}`;
     }
     if ((unit as any)?.name) {
-      return (unit as any).name;
+      return `${formattedDomainName}${(unit as any).name}`;
     }
   }
 
@@ -459,6 +470,16 @@ function getName(unit: Node | Unit<any>): string | null {
   }
 
   return null;
+}
+
+function getOwningDomainName(unit: Node | Unit<any>): string | null {
+  const closestParentDomain = getNode(unit).family.owners.find(
+    (n) => n.meta.op === 'domain',
+  );
+
+  if (!closestParentDomain) return null;
+
+  return getName(closestParentDomain);
 }
 
 function readLoc({

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -11,8 +11,39 @@ import {
   Scope,
 } from 'effector';
 
+type LogContext =
+  | {
+      type: 'log';
+      /** common */
+      scope: Scope | null;
+      scopeName: string | null;
+      node: Node;
+      value: unknown;
+      name: string;
+      timestamp: number;
+      /** trace only */
+      trace?: never;
+    }
+  | {
+      type: 'traceStart' | 'traceEnd' | 'trace';
+      /** common */
+      scope: Scope | null;
+      scopeName: string | null;
+      node: Node;
+      value: unknown;
+      name: string;
+      timestamp: number;
+      /** trace only */
+      trace: {
+        ofNode: Node;
+        ofValue: unknown;
+      };
+    };
+
 interface Config {
   trace?: boolean;
+  now?: () => number;
+  handler?: (context: LogContext) => void;
 }
 
 function isConfig(

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -243,7 +243,7 @@ function logUnit(unit: Unit<any>, config?: Config) {
         logTrace(store);
       }
     });
-    unit.onCreateEffect(effect => {
+    unit.onCreateEffect((effect) => {
       log(effect, 'effect');
       logEffect(effect);
       if (config?.trace) {

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -87,6 +87,7 @@ function watchUnit(
   config: Config,
 ) {
   if (is.store(unit)) {
+    // store has its initial/current value - we can log it right away
     watchStoreInitial(unit, config);
     watch(unit, config);
   } else if (is.event(unit)) {
@@ -111,6 +112,7 @@ function watch(unit: Unit<any>, config: Config) {
         fn(value: unknown, _internal: unknown, stack: Stack) {
           const scope = stack?.scope ?? null;
 
+          // If new unknown scope is found - save it
           if (scope && !scopes.get(scope)) {
             scopes.save(scope);
           }
@@ -122,6 +124,7 @@ function watch(unit: Unit<any>, config: Config) {
             kind: getType(unit),
             value,
             name: getName(unit),
+            loc: getLoc(unit),
             trace: config.trace ? collectTrace(stack) : undefined,
           };
 
@@ -153,6 +156,7 @@ function collectTrace(stack: Stack): Trace {
       node,
       value,
       name: getNodeName(node),
+      loc: getLoc(node),
       kind: getType(node),
     };
 
@@ -179,6 +183,7 @@ function watchStoreInitial(store: Store<any>, config: Config) {
     kind: getType(store),
     value: store.getState(),
     name: getName(store),
+    loc: getLoc(store),
     trace: config.trace ? [] : undefined,
   };
 
@@ -205,6 +210,7 @@ function watchStoreInitialInScope(store: Store<any>, config: Config, scope: Scop
     kind: getType(store),
     value: scope.getState(store),
     name: getName(store),
+    loc: getLoc(store),
     trace: config.trace ? [] : undefined,
   };
 
@@ -429,7 +435,7 @@ function readLoc({
 function getLoc(unit: Node | Unit<any>) {
   const loc = readLoc(getNode(unit));
 
-  if (!loc) return null;
+  if (!loc) return undefined;
 
   return loc;
 }

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -20,29 +20,27 @@ type LogContext =
       node: Node;
       value: unknown;
       name: string;
-      timestamp: number;
       /** trace only */
       trace?: never;
     }
   | {
-      type: 'traceStart' | 'traceEnd' | 'trace';
+      type: 'trace';
       /** common */
       scope: Scope | null;
       scopeName: string | null;
       node: Node;
       value: unknown;
       name: string;
-      timestamp: number;
       /** trace only */
       trace: {
-        ofNode: Node;
-        ofValue: unknown;
-      };
+        node: Node;
+        name: string;
+        value: unknown;
+      }[];
     };
 
 interface Config {
   trace?: boolean;
-  now?: () => number;
   handler?: (context: LogContext) => void;
 }
 

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -14,6 +14,7 @@ import {
 } from 'effector';
 
 type LogContext = {
+  logType: 'storeInit' | 'update';
   scope: Scope | null;
   scopeName: string | null;
   /** node, kind, value, name - common fields for logs and traces */

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -14,7 +14,7 @@ import {
 } from 'effector';
 
 type LogContext = {
-  logType: 'storeInit' | 'update';
+  logType: 'initial' | 'update';
   scope: Scope | null;
   scopeName: string | null;
   /** node, kind, value, name - common fields for logs and traces */
@@ -116,7 +116,7 @@ function watchUnit(
 ) {
   if (is.store(unit)) {
     // store has its initial/current value - we can log it right away
-    watchStoreInitial(unit, config);
+    watchinitialial(unit, config);
     watch(unit, config);
   } else if (is.event(unit)) {
     watch(unit, config);
@@ -146,6 +146,7 @@ function watch(unit: Unit<any>, config: Config) {
           }
 
           const context: LogContext = {
+            logType: 'update',
             scope,
             scopeName: getScopeName(scope),
             node: getNode(unit),
@@ -196,7 +197,7 @@ function collectTrace(stack: Stack): Trace {
   return trace;
 }
 
-function watchStoreInitial(store: Store<any>, config: Config) {
+function watchinitialial(store: Store<any>, config: Config) {
   if (!config.handler) {
     throw Error('patronum/debug must have the handler');
   }
@@ -205,6 +206,7 @@ function watchStoreInitial(store: Store<any>, config: Config) {
 
   // current state
   const context: LogContext = {
+    logType: 'initial',
     scope: null,
     scopeName: null,
     node,
@@ -218,12 +220,12 @@ function watchStoreInitial(store: Store<any>, config: Config) {
   config.handler(context);
 
   // current state in every known scope
-  scopes.forEach((scope) => watchStoreInitialInScope(store, config, scope));
+  scopes.forEach((scope) => watchinitialialInScope(store, config, scope));
   // subscribe to new scopes
-  watchScopeRegister((newScope) => watchStoreInitialInScope(store, config, newScope));
+  watchScopeRegister((newScope) => watchinitialialInScope(store, config, newScope));
 }
 
-function watchStoreInitialInScope(store: Store<any>, config: Config, scope: Scope) {
+function watchinitialialInScope(store: Store<any>, config: Config, scope: Scope) {
   if (!config.handler) {
     throw Error('patronum/debug must have the handler');
   }
@@ -232,6 +234,7 @@ function watchStoreInitialInScope(store: Store<any>, config: Config, scope: Scop
 
   // current state
   const context: LogContext = {
+    logType: 'initial',
     scope,
     scopeName: getScopeName(scope),
     node,

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -117,7 +117,7 @@ function watchUnit(
 ) {
   if (is.store(unit)) {
     // store has its initial/current value - we can log it right away
-    watchinitialial(unit, config);
+    watchStoreInit(unit, config);
     watch(unit, config);
   } else if (is.event(unit)) {
     watch(unit, config);
@@ -198,7 +198,7 @@ function collectTrace(stack: Stack): Trace {
   return trace;
 }
 
-function watchinitialial(store: Store<any>, config: Config) {
+function watchStoreInit(store: Store<any>, config: Config) {
   if (!config.handler) {
     throw Error('patronum/debug must have the handler');
   }
@@ -221,12 +221,12 @@ function watchinitialial(store: Store<any>, config: Config) {
   config.handler(context);
 
   // current state in every known scope
-  scopes.forEach((scope) => watchinitialialInScope(store, config, scope));
+  scopes.forEach((scope) => watchStoreInitInScope(store, config, scope));
   // subscribe to new scopes
-  watchScopeRegister((newScope) => watchinitialialInScope(store, config, newScope));
+  watchScopeRegister((newScope) => watchStoreInitInScope(store, config, newScope));
 }
 
-function watchinitialialInScope(store: Store<any>, config: Config, scope: Scope) {
+function watchStoreInitInScope(store: Store<any>, config: Config, scope: Scope) {
   if (!config.handler) {
     throw Error('patronum/debug must have the handler');
   }

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -188,6 +188,7 @@ Handler is called for each update with context object like this:
 
 Common fields:
 
+- **logType** - `storeInit | update` - log type for convenience. All provided stores current values are logged with `storeInit` for all known scopes right away. Same after new scope was registered. All other updates are of `update` type.
 - **scope** - `Scope | null` - effector's `Scope` context object, which owns this particular update
 - **scopeName** - `string | null` - name of the `Scope`, if registered and `null` otherwise.
 - **node** - `Node` - effector's internal node, which update is being logged.

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -191,14 +191,14 @@ Common fields:
 - **scope** - `Scope | null` - effector's `Scope` context object, which owns this particular update
 - **scopeName** - `string | null` - name of the `Scope`, if registered and `null` otherwise.
 - **node** - `Node` - effector's internal node, which update is being logged.
-- **name** - `string` - node's name for convenience.
+- **name** - `string | null` - node's name for convenience. `null` - if node doesn't have own name (like `sample` calls).
 - **kind** - `string` - node's kind for convenience. It can be unit's kind (e.g. `store` or `event`) or operation kind (e.g. `sample`, `split`, etc).
 - **value** - `unknown` - value of the update.
 - **loc** - `{ file?: string; line: number; column: number; }` - location in the source code, if known
 
 Special field if `trace: true` provided:
 
-- **trace** - `undefined | { node: Node; name: string; kind: string; value: unknown; loc?: Loc }[]` - trace of updates.
+- **trace** - `undefined | { node: Node; name: string | null; kind: string; value: unknown; loc?: Loc }[]` - trace of updates.
 
 The `trace` field is not provided, if `debug`'s config does not have `trace: true`.
 

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -179,3 +179,53 @@ debug($count);
 // "[store] (scope: scope_42) $count 42",
 // "[store] (scope: scope_1337) $count 1337",
 ```
+
+### Custom log handler
+
+You can provide custom log handler in the config. It can be useful, if `console.log` somehow doesn't fit your use-case: e.g. you want advanced info from `patronum/debug` to built your own dev-tools, debug especially hard case, etc.
+
+Handler is called for each update with context object like this:
+
+Common fields:
+
+- **type** - `"log" | "traceStart" | "traceEnd" | "trace"` - describes which kind of log it is - basic unit update log or trace log.
+- **scope** - `Scope | null` - effector's `Scope` context object, which owns this particular update
+- **scopeName** - `string | null` - name of the `Scope`, if registered and `null` otherwise.
+- **node** - `Node` - effector's internal node, which update is being logged.
+- **name** - `string` - node's name for convenience.
+- **value** - `unknown` - value of the update.
+- **timestamp** - `number` - timestamp of this update, calculated via `performance.now` by default, can be customized by proiding custom `now` function in the `debug` config.
+
+Special field for `type: "trace"` is `trace` object, which contains fields like:
+
+- **trace.ofNode** - `Node` - effector's node, which update trace is being logged.
+- **trace.ofValue** - `unknown` - value of effector's node, which update trace is being logged.
+
+The `trace` field is not provided`, if `debug`'s config does not have `trace: true`.
+
+```ts
+debug({
+  trace: true,
+  // custom timer
+  now: () => Date.now(),
+  // custom log handler
+  handler: ({ type, trace, scope, scopeName, node, value }) => {
+    if (type === 'log') {
+      // your own way to log updates
+      doStuff(node, value);
+    }
+
+    if (type === 'traceStart') {
+      // log something like "trace of $store"
+    }
+
+    if (type === 'trace') {
+      // log trace part
+    }
+
+    if (type === 'traceEnd') {
+      // log the end of the trace
+    }
+  },
+});
+```

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -199,9 +199,9 @@ Common fields:
 
 Special field if `trace: true` provided:
 
-- **trace** - `undefined | { node: Node; name: string | null; kind: string; value: unknown; loc?: Loc }[]` - trace of updates.
+- **trace** - `Array<{ node: Node; name: string | null; kind: string; value: unknown; loc?: Loc }>` - trace of updates.
 
-The `trace` field is not provided, if `debug`'s config does not have `trace: true`.
+The `trace` array is always empty (i.e. trace is not collected), if `debug`'s config does not have `trace: true`.
 
 ```ts
 debug(

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -188,26 +188,21 @@ Handler is called for each update with context object like this:
 
 Common fields:
 
-- **type** - `"log" | "traceStart" | "traceEnd" | "trace"` - describes which kind of log it is - basic unit update log or trace log.
+- **type** - `"log" | "trace"` - describes which kind of log it is - basic unit update log or trace log.
 - **scope** - `Scope | null` - effector's `Scope` context object, which owns this particular update
 - **scopeName** - `string | null` - name of the `Scope`, if registered and `null` otherwise.
 - **node** - `Node` - effector's internal node, which update is being logged.
 - **name** - `string` - node's name for convenience.
 - **value** - `unknown` - value of the update.
-- **timestamp** - `number` - timestamp of this update, calculated via `performance.now` by default, can be customized by proiding custom `now` function in the `debug` config.
 
-Special field for `type: "trace"` is `trace` object, which contains fields like:
-
-- **trace.ofNode** - `Node` - effector's node, which update trace is being logged.
-- **trace.ofValue** - `unknown` - value of effector's node, which update trace is being logged.
+Special field for `type: "trace"`:
+- **trace** - `{ node: Node; name: string; value: unknown; }[]` - trace of updates.
 
 The `trace` field is not provided`, if `debug`'s config does not have `trace: true`.
 
 ```ts
 debug({
   trace: true,
-  // custom timer
-  now: () => Date.now(),
   // custom log handler
   handler: ({ type, trace, scope, scopeName, node, value }) => {
     if (type === 'log') {
@@ -215,16 +210,9 @@ debug({
       doStuff(node, value);
     }
 
-    if (type === 'traceStart') {
-      // log something like "trace of $store"
-    }
-
     if (type === 'trace') {
       // log trace part
-    }
-
-    if (type === 'traceEnd') {
-      // log the end of the trace
+      trace.forEach(({ name, node, value }) => doStuff(node, value));
     }
   },
 });

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -194,25 +194,29 @@ Common fields:
 - **name** - `string` - node's name for convenience.
 - **kind** - `string` - node's kind for convenience. It can be unit's kind (e.g. `store` or `event`) or operation kind (e.g. `sample`, `split`, etc).
 - **value** - `unknown` - value of the update.
+- **loc** - `{ file?: string; line: number; column: number; }` - location in the source code, if known
 
 Special field if `trace: true` provided:
 
-- **trace** - `undefined | { node: Node; name: string; kind: string; value: unknown; }[]` - trace of updates.
+- **trace** - `undefined | { node: Node; name: string; kind: string; value: unknown; loc?: Loc }[]` - trace of updates.
 
 The `trace` field is not provided, if `debug`'s config does not have `trace: true`.
 
 ```ts
-debug({
-  trace: true,
-  // custom log handler
-  handler: ({ trace, scope, scopeName, node, value, name, kind }) => {
-    // your own way to log updates
-    doStuff(node, value);
+debug(
+  {
+    trace: true,
+    // custom log handler
+    handler: ({ trace, scope, scopeName, node, value, name, kind }) => {
+      // your own way to log updates
+      doStuff(node, value);
 
-    if (trace) {
-      // log trace part
-      trace.forEach(({ name, kind, node, value }) => doStuff(node, value));
-    }
+      if (trace) {
+        // log trace part
+        trace.forEach(({ name, kind, node, value }) => doStuff(node, value));
+      }
+    },
   },
-}, { $a, $b, c });
+  { $a, $b, c },
+);
 ```

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -188,7 +188,6 @@ Handler is called for each update with context object like this:
 
 Common fields:
 
-- **type** - `"log" | "trace"` - describes which kind of log it is - basic unit update log or trace log.
 - **scope** - `Scope | null` - effector's `Scope` context object, which owns this particular update
 - **scopeName** - `string | null` - name of the `Scope`, if registered and `null` otherwise.
 - **node** - `Node` - effector's internal node, which update is being logged.
@@ -196,21 +195,20 @@ Common fields:
 - **value** - `unknown` - value of the update.
 
 Special field for `type: "trace"`:
-- **trace** - `{ node: Node; name: string; value: unknown; }[]` - trace of updates.
 
-The `trace` field is not provided`, if `debug`'s config does not have `trace: true`.
+- **trace** - `undefined | { node: Node; name: string; value: unknown; }[]` - trace of updates.
+
+The `trace` field is not provided, if `debug`'s config does not have `trace: true`.
 
 ```ts
 debug({
   trace: true,
   // custom log handler
   handler: ({ type, trace, scope, scopeName, node, value }) => {
-    if (type === 'log') {
-      // your own way to log updates
-      doStuff(node, value);
-    }
+    // your own way to log updates
+    doStuff(node, value);
 
-    if (type === 'trace') {
+    if (trace) {
       // log trace part
       trace.forEach(({ name, node, value }) => doStuff(node, value));
     }

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -195,7 +195,7 @@ Common fields:
 - **kind** - `string` - node's kind for convenience. It can be unit's kind (e.g. `store` or `event`) or operation kind (e.g. `sample`, `split`, etc).
 - **value** - `unknown` - value of the update.
 
-Special field for `type: "trace"`:
+Special field if `trace: true` provided:
 
 - **trace** - `undefined | { node: Node; name: string; kind: string; value: unknown; }[]` - trace of updates.
 
@@ -214,5 +214,5 @@ debug({
       trace.forEach(({ name, kind, node, value }) => doStuff(node, value));
     }
   },
-});
+}, { $a, $b, c });
 ```

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -192,11 +192,12 @@ Common fields:
 - **scopeName** - `string | null` - name of the `Scope`, if registered and `null` otherwise.
 - **node** - `Node` - effector's internal node, which update is being logged.
 - **name** - `string` - node's name for convenience.
+- **kind** - `string` - node's kind for convenience. It can be unit's kind (e.g. `store` or `event`) or operation kind (e.g. `sample`, `split`, etc).
 - **value** - `unknown` - value of the update.
 
 Special field for `type: "trace"`:
 
-- **trace** - `undefined | { node: Node; name: string; value: unknown; }[]` - trace of updates.
+- **trace** - `undefined | { node: Node; name: string; kind: string; value: unknown; }[]` - trace of updates.
 
 The `trace` field is not provided, if `debug`'s config does not have `trace: true`.
 
@@ -204,13 +205,13 @@ The `trace` field is not provided, if `debug`'s config does not have `trace: tru
 debug({
   trace: true,
   // custom log handler
-  handler: ({ type, trace, scope, scopeName, node, value }) => {
+  handler: ({ trace, scope, scopeName, node, value, name, kind }) => {
     // your own way to log updates
     doStuff(node, value);
 
     if (trace) {
       // log trace part
-      trace.forEach(({ name, node, value }) => doStuff(node, value));
+      trace.forEach(({ name, kind, node, value }) => doStuff(node, value));
     }
   },
 });

--- a/src/debug/readme.md
+++ b/src/debug/readme.md
@@ -188,7 +188,7 @@ Handler is called for each update with context object like this:
 
 Common fields:
 
-- **logType** - `storeInit | update` - log type for convenience. All provided stores current values are logged with `storeInit` for all known scopes right away. Same after new scope was registered. All other updates are of `update` type.
+- **logType** - `initial | update` - log type for convenience. All provided stores current values are logged with `initial` for all known scopes right away. Same after new scope was registered. All other updates are of `update` type.
 - **scope** - `Scope | null` - effector's `Scope` context object, which owns this particular update
 - **scopeName** - `string | null` - name of the `Scope`, if registered and `null` otherwise.
 - **node** - `Node` - effector's internal node, which update is being logged.

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -95,7 +95,7 @@ import { debug } from '../src/debug';
           context.trace.forEach((update) => {
             expectType<Node>(update.node);
             expectType<string>(update.name);
-            expectType<string>(context.kind);
+            expectType<string>(update.kind);
             expectType<unknown>(update.value);
           });
         }

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -98,24 +98,22 @@ import { debug } from '../src/debug';
             }
         >(context.loc);
 
-        if (context.trace) {
-          expectType<Array<any>>(context.trace);
+        expectType<Array<any>>(context.trace);
 
-          context.trace.forEach((update) => {
-            expectType<Node>(update.node);
-            expectType<string | null>(update.name);
-            expectType<string>(update.kind);
-            expectType<unknown>(update.value);
-            expectType<
-              | undefined
-              | {
-                  file?: string;
-                  line: number;
-                  column: number;
-                }
-            >(update.loc);
-          });
-        }
+        context.trace.forEach((update) => {
+          expectType<Node>(update.node);
+          expectType<string | null>(update.name);
+          expectType<string>(update.kind);
+          expectType<unknown>(update.value);
+          expectType<
+            | undefined
+            | {
+                file?: string;
+                line: number;
+                column: number;
+              }
+          >(update.loc);
+        });
       },
     },
     { event, $store, fx, domain },

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -83,6 +83,7 @@ import { debug } from '../src/debug';
       trace: true,
       handler: (context) => {
         expectType<string>(context.name);
+        expectType<string>(context.kind);
         expectType<Node>(context.node);
         expectType<Scope | null>(context.scope);
         expectType<string | null>(context.scopeName);
@@ -94,6 +95,7 @@ import { debug } from '../src/debug';
           context.trace.forEach((update) => {
             expectType<Node>(update.node);
             expectType<string>(update.name);
+            expectType<string>(context.kind);
             expectType<unknown>(update.value);
           });
         }

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -82,17 +82,21 @@ import { debug } from '../src/debug';
     {
       trace: true,
       handler: (context) => {
+        expectType<'storeInit' | 'update'>(context.logType);
         expectType<string | null>(context.name);
         expectType<string>(context.kind);
         expectType<Node>(context.node);
         expectType<Scope | null>(context.scope);
         expectType<string | null>(context.scopeName);
         expectType<unknown>(context.value);
-        expectType<undefined | {
-          file?: string;
-          line: number;
-          column: number;
-        }>(context.loc)
+        expectType<
+          | undefined
+          | {
+              file?: string;
+              line: number;
+              column: number;
+            }
+        >(context.loc);
 
         if (context.trace) {
           expectType<Array<any>>(context.trace);
@@ -102,11 +106,14 @@ import { debug } from '../src/debug';
             expectType<string | null>(update.name);
             expectType<string>(update.kind);
             expectType<unknown>(update.value);
-            expectType<undefined | {
-              file?: string;
-              line: number;
-              column: number;
-            }>(update.loc)
+            expectType<
+              | undefined
+              | {
+                  file?: string;
+                  line: number;
+                  column: number;
+                }
+            >(update.loc);
           });
         }
       },

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -82,7 +82,7 @@ import { debug } from '../src/debug';
     {
       trace: true,
       handler: (context) => {
-        expectType<'storeInit' | 'update'>(context.logType);
+        expectType<'initial' | 'update'>(context.logType);
         expectType<string | null>(context.name);
         expectType<string>(context.kind);
         expectType<Node>(context.node);

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -82,65 +82,25 @@ import { debug } from '../src/debug';
     {
       trace: true,
       handler: (context) => {
-        expectType<'log' | 'traceStart' | 'traceEnd' | 'trace'>(context.type);
+        expectType<'log' | 'trace'>(context.type);
         expectType<string>(context.name);
         expectType<Node>(context.node);
         expectType<Scope | null>(context.scope);
         expectType<string | null>(context.scopeName);
         expectType<unknown>(context.value);
-        expectType<number>(context.timestamp);
 
         if (context.type === 'log') {
           expectType<undefined>(context.trace);
         }
 
         if (context.type === 'trace') {
-          expectType<Node>(context.trace.ofNode);
-          expectType<unknown>(context.trace.ofValue);
-        }
+          expectType<Array<any>>(context.trace);
 
-        if (context.type === 'traceStart' || context.type === 'traceEnd') {
-          expectType<Node>(context.trace.ofNode);
-          expectType<unknown>(context.trace.ofValue);
-        }
-      },
-    },
-    { event, $store, fx, domain },
-  );
-}
-
-// Allows custom timer for handler
-{
-  const event = createEvent<number>();
-  const $store = createStore('');
-  const fx = createEffect<boolean, void, number>();
-  const domain = createDomain();
-
-  debug(
-    {
-      trace: true,
-      now: () => 42,
-      handler: (context) => {
-        expectType<'log' | 'traceStart' | 'traceEnd' | 'trace'>(context.type);
-        expectType<string>(context.name);
-        expectType<Node>(context.node);
-        expectType<Scope | null>(context.scope);
-        expectType<string | null>(context.scopeName);
-        expectType<unknown>(context.value);
-        expectType<number>(context.timestamp);
-
-        if (context.type === 'log') {
-          expectType<undefined>(context.trace);
-        }
-
-        if (context.type === 'trace') {
-          expectType<Node>(context.trace.ofNode);
-          expectType<unknown>(context.trace.ofValue);
-        }
-
-        if (context.type === 'traceStart' || context.type === 'traceEnd') {
-          expectType<Node>(context.trace.ofNode);
-          expectType<unknown>(context.trace.ofValue);
+          context.trace.forEach((update) => {
+            expectType<Node>(update.node);
+            expectType<string>(update.name);
+            expectType<unknown>(update.value);
+          });
         }
       },
     },

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -88,6 +88,11 @@ import { debug } from '../src/debug';
         expectType<Scope | null>(context.scope);
         expectType<string | null>(context.scopeName);
         expectType<unknown>(context.value);
+        expectType<undefined | {
+          file?: string;
+          line: number;
+          column: number;
+        }>(context.loc)
 
         if (context.trace) {
           expectType<Array<any>>(context.trace);
@@ -97,6 +102,11 @@ import { debug } from '../src/debug';
             expectType<string>(update.name);
             expectType<string>(update.kind);
             expectType<unknown>(update.value);
+            expectType<undefined | {
+              file?: string;
+              line: number;
+              column: number;
+            }>(update.loc)
           });
         }
       },

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -82,18 +82,13 @@ import { debug } from '../src/debug';
     {
       trace: true,
       handler: (context) => {
-        expectType<'log' | 'trace'>(context.type);
         expectType<string>(context.name);
         expectType<Node>(context.node);
         expectType<Scope | null>(context.scope);
         expectType<string | null>(context.scopeName);
         expectType<unknown>(context.value);
 
-        if (context.type === 'log') {
-          expectType<undefined>(context.trace);
-        }
-
-        if (context.type === 'trace') {
+        if (context.trace) {
           expectType<Array<any>>(context.trace);
 
           context.trace.forEach((update) => {

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -82,7 +82,7 @@ import { debug } from '../src/debug';
     {
       trace: true,
       handler: (context) => {
-        expectType<string>(context.name);
+        expectType<string | null>(context.name);
         expectType<string>(context.kind);
         expectType<Node>(context.node);
         expectType<Scope | null>(context.scope);
@@ -99,7 +99,7 @@ import { debug } from '../src/debug';
 
           context.trace.forEach((update) => {
             expectType<Node>(update.node);
-            expectType<string>(update.name);
+            expectType<string | null>(update.name);
             expectType<string>(update.kind);
             expectType<unknown>(update.value);
             expectType<undefined | {

--- a/test-typings/debug.ts
+++ b/test-typings/debug.ts
@@ -1,5 +1,12 @@
 import { expectType } from 'tsd';
-import { createEvent, createDomain, createEffect, createStore } from 'effector';
+import {
+  createEvent,
+  createDomain,
+  createEffect,
+  createStore,
+  type Node,
+  type Scope,
+} from 'effector';
 import { debug } from '../src/debug';
 
 // Allows each unit of effector
@@ -43,4 +50,100 @@ import { debug } from '../src/debug';
 
   // @ts-expect-error
   debug(event, { trace: true }, $store, fx, domain);
+}
+
+// Allows shape of units
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+
+  debug({ event, $store, fx, domain });
+}
+
+// Allows shape of units with config
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+  debug({ trace: true }, { event, $store, fx, domain });
+}
+
+// Allows custom handler
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+
+  debug(
+    {
+      trace: true,
+      handler: (context) => {
+        expectType<'log' | 'traceStart' | 'traceEnd' | 'trace'>(context.type);
+        expectType<string>(context.name);
+        expectType<Node>(context.node);
+        expectType<Scope | null>(context.scope);
+        expectType<string | null>(context.scopeName);
+        expectType<unknown>(context.value);
+        expectType<number>(context.timestamp);
+
+        if (context.type === 'log') {
+          expectType<undefined>(context.trace);
+        }
+
+        if (context.type === 'trace') {
+          expectType<Node>(context.trace.ofNode);
+          expectType<unknown>(context.trace.ofValue);
+        }
+
+        if (context.type === 'traceStart' || context.type === 'traceEnd') {
+          expectType<Node>(context.trace.ofNode);
+          expectType<unknown>(context.trace.ofValue);
+        }
+      },
+    },
+    { event, $store, fx, domain },
+  );
+}
+
+// Allows custom timer for handler
+{
+  const event = createEvent<number>();
+  const $store = createStore('');
+  const fx = createEffect<boolean, void, number>();
+  const domain = createDomain();
+
+  debug(
+    {
+      trace: true,
+      now: () => 42,
+      handler: (context) => {
+        expectType<'log' | 'traceStart' | 'traceEnd' | 'trace'>(context.type);
+        expectType<string>(context.name);
+        expectType<Node>(context.node);
+        expectType<Scope | null>(context.scope);
+        expectType<string | null>(context.scopeName);
+        expectType<unknown>(context.value);
+        expectType<number>(context.timestamp);
+
+        if (context.type === 'log') {
+          expectType<undefined>(context.trace);
+        }
+
+        if (context.type === 'trace') {
+          expectType<Node>(context.trace.ofNode);
+          expectType<unknown>(context.trace.ofValue);
+        }
+
+        if (context.type === 'traceStart' || context.type === 'traceEnd') {
+          expectType<Node>(context.trace.ofNode);
+          expectType<unknown>(context.trace.ofValue);
+        }
+      },
+    },
+    { event, $store, fx, domain },
+  );
 }


### PR DESCRIPTION
custom log handler in the config can be useful, if `console.log` is not enough. e.g. you want advanced info from `patronum/debug` to built your own dev-tools, debug especially hard case, etc.

Closes #258 