### PR TITLE
Fix debounce with void events

### DIFF
--- a/src/debounce/debounce.test.ts
+++ b/src/debounce/debounce.test.ts
@@ -569,3 +569,17 @@ test('debounce do not affect another instance of debounce', async () => {
   await wait(20);
   expect(watcherSecond).toBeCalledWith('foo');
 });
+
+test('debounced event should be triggered with undefined', async () => {
+  const trigger = createEvent();
+  const debounced = debounce({ source: trigger, timeout: 10 });
+
+  const listener = jest.fn();
+  debounced.watch(listener);
+
+  trigger();
+  await wait(20);
+
+  expect(listener).toBeCalledTimes(1);
+  expect(listener).toBeCalledWith(undefined);
+});

--- a/src/debounce/debounce.test.ts
+++ b/src/debounce/debounce.test.ts
@@ -572,13 +572,13 @@ test('debounce do not affect another instance of debounce', async () => {
 
 test('debounced event should be triggered with undefined', async () => {
   const trigger = createEvent();
-  const debounced = debounce({ source: trigger, timeout: 10 });
+  const debounced = debounce({ source: trigger, timeout: 0 });
 
   const listener = jest.fn();
   debounced.watch(listener);
 
   trigger();
-  await wait(20);
+  await wait(0);
 
   expect(listener).toBeCalledTimes(1);
   expect(listener).toBeCalledWith(undefined);

--- a/src/debounce/index.ts
+++ b/src/debounce/index.ts
@@ -87,7 +87,7 @@ export function debounce<T>({
   $timeoutId.reset(timerFx.done);
 
   // It's ok - nothing will ever start unless source is triggered
-  const $payload = createStore<[T?]>([], { serialize: 'ignore' }).on(
+  const $payload = createStore<T[]>([], { serialize: 'ignore' }).on(
     source,
     (_, payload) => [payload],
   );
@@ -130,7 +130,7 @@ export function debounce<T>({
   sample({
     source: $payload,
     clock: timerFx.done,
-    fn: ([payload]) => payload as T,
+    fn: ([payload]) => payload,
     target: tick,
   });
 

--- a/src/debounce/index.ts
+++ b/src/debounce/index.ts
@@ -87,9 +87,9 @@ export function debounce<T>({
   $timeoutId.reset(timerFx.done);
 
   // It's ok - nothing will ever start unless source is triggered
-  const $payload = createStore<T>(null as unknown as T, { serialize: 'ignore' }).on(
+  const $payload = createStore<[T?]>([], { serialize: 'ignore' }).on(
     source,
-    (_, payload) => payload,
+    (_, payload) => [payload],
   );
 
   const $canTick = createStore(true, { serialize: 'ignore' });
@@ -130,6 +130,7 @@ export function debounce<T>({
   sample({
     source: $payload,
     clock: timerFx.done,
+    fn: ([payload]) => payload as T,
     target: tick,
   });
 


### PR DESCRIPTION
Fix `debounce` with void events.

```js
import { debounce } from 'patronum'

const event = createEvent()
const debounced = debounce({ source: event, timeout: 10 })

event.watch(_ => console.log('event:', _))
debounced.watch(_ => console.log('debounced:', _))

event()
```
this code will trigger `debounced` event with `null` instead of `undefined`.

This PR fixes this.