### PR TITLE
Do not infer time param and add type tests for `time` operator

### DIFF
--- a/src/time/index.ts
+++ b/src/time/index.ts
@@ -2,6 +2,8 @@ import { createEffect, Effect, Event, forward, restore, Store } from 'effector';
 
 const defaultNow = <Time = number>() => Date.now() as unknown as Time;
 
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
 export function time<Time = number>({
   clock,
   getNow,
@@ -9,7 +11,7 @@ export function time<Time = number>({
 }: {
   clock: Event<any> | Effect<any, any, any> | Store<any>;
   getNow?: () => Time;
-  initial?: Time;
+  initial?: NoInfer<Time>;
 }): Store<Time> {
   const timeReader = getNow ?? defaultNow;
   const readNowFx = createEffect<void, Time>(timeReader);

--- a/src/time/time.fork.test.ts
+++ b/src/time/time.fork.test.ts
@@ -42,12 +42,12 @@ test('store must correctly serializes', async () => {
   await allSettled(clock, { scope: scopeB });
   expect(serialize(scopeA)).toMatchInlineSnapshot(`
     {
-      "-9m03zk|-ys9vce": 2,
+      "-9m03zk|-xu6mk0": 2,
     }
   `);
   expect(serialize(scopeB)).toMatchInlineSnapshot(`
     {
-      "-9m03zk|-ys9vce": 3,
+      "-9m03zk|-xu6mk0": 3,
     }
   `);
 });

--- a/test-typings/time.ts
+++ b/test-typings/time.ts
@@ -1,0 +1,75 @@
+import { expectType } from 'tsd';
+import { Store, createStore, createEvent, createEffect, createDomain } from 'effector';
+import { time } from '../src/time';
+
+// Returns correct default Store value
+{
+  const clock = createEvent<void>();
+
+  expectType<Store<number>>(time({ clock }));
+  expectType<Store<number>>(time({ clock, initial: 100 }));
+}
+
+// Infers correct Store value
+{
+  const clock = createEvent<void>();
+
+  const getNowString = (): string => 'time';
+  const getNowNumber = (): number => 0;
+  const getNowDate = (): Date => new Date();
+
+  expectType<Store<string>>(time({ clock, getNow: getNowString }));
+  expectType<Store<number>>(time({ clock, getNow: getNowNumber }));
+  expectType<Store<Date>>(time({ clock, getNow: getNowDate }));
+
+  const getNowUnion = (): 'a' | 'b' | 0 => 'a';
+
+  expectType<Store<'a' | 'b' | 0>>(time({ clock, getNow: getNowUnion }));
+}
+
+// getNow and initial types should match
+{
+  const clock = createEvent<void>();
+
+  const getNowString = (): string => 'time';
+  const getNowDate = (): Date => new Date();
+
+  expectType<Store<Date>>(time({ clock, getNow: getNowDate, initial: new Date() }));
+  expectType<Store<string>>(
+    time({ clock, getNow: getNowString, initial: 'another' }),
+  );
+
+  // @ts-expect-error
+  time({ clock, getNow: getNowString, initial: 100 });
+  // @ts-expect-error
+  time({ clock, getNow: getNowDate, initial: 100 });
+}
+
+// Does not infer Store value from initial
+{
+  const clock = createEvent<void>();
+
+  // @ts-expect-error
+  time({ clock, initial: new Date() });
+  // @ts-expect-error
+  time({ clock, initial: 'time' });
+}
+
+// Clock only accepts valid units
+{
+  const event = createEvent<void>();
+  const effectFx = createEffect<void, void, void>();
+  const $store = createStore<void>(undefined);
+
+  expectType<Store<number>>(time({ clock: event }));
+  expectType<Store<number>>(time({ clock: effectFx }));
+  expectType<Store<number>>(time({ clock: $store }));
+
+  const fn = () => null;
+  const domain = createDomain()
+
+  // @ts-expect-error
+  time({ clock: fn });
+  // @ts-expect-error
+  time({ clock: domain });
+}


### PR DESCRIPTION
Closes #274 

### Checklist for a ~~new~~ existing method (`time`)

- [x] Add **type** tests to `test-typings/time.ts`
  - Use `// @ts-expect-error` to mark expected type error
  - `import { expectType } from 'tsd'` to check expected return type

---

I've added a `NoInfer` on the `initial` argument. I'm not sure that's the right approach, but that way it does not allow passing `initial` with a value incompatible with a default `getNow` function, which should not be possible.
