### PR TITLE
Allow `clock` in `snapshot` to be a Store or Effect and do not infer return value

### DIFF
--- a/src/snapshot/index.ts
+++ b/src/snapshot/index.ts
@@ -1,4 +1,6 @@
-import { createStore, Event, sample, Store } from 'effector';
+import { createStore, Effect, sample, Store, Unit, Event } from 'effector';
+
+type NoInfer<T> = [T][T extends any ? 0 : never];
 
 export function snapshot<SourceType, TargetType = SourceType>({
   source,
@@ -6,11 +8,13 @@ export function snapshot<SourceType, TargetType = SourceType>({
   fn = (value: SourceType) => value as unknown as TargetType,
 }: {
   source: Store<SourceType>;
-  clock?: Event<any>;
+  clock?: Event<any> | Effect<any, any, any> | Store<any>;
   fn?(value: SourceType): TargetType;
-}): Store<TargetType> {
+}): Store<NoInfer<TargetType>> {
   const defaultValue = fn(source.defaultState);
-  const onSnapshot = clock ? sample({ source, clock, fn }) : sample({ source, fn });
+  const onSnapshot = clock
+    ? sample({ source, clock: clock as Unit<any>, fn })
+    : sample({ source, fn });
   const $snapshot = createStore(defaultValue);
 
   $snapshot.on(onSnapshot, (_, value) => value);

--- a/src/snapshot/readme.md
+++ b/src/snapshot/readme.md
@@ -14,7 +14,7 @@ import { snapshot } from 'patronum/snapshot';
 
 ### Motivation
 
-This method allows to copy any store on optional trigger event.
+This method allows to copy any store on optional trigger unit.
 It useful when you want to save previous state of store before some actions.
 
 ### Formulae
@@ -24,12 +24,12 @@ result = snapshot({ source, clock, fn });
 ```
 
 - Call `fn` with data from `source` while `clock` triggered, and create store with the value
-- If function in `shape` returns `undefined`, the update will be skipped.
+- If `fn` returns `undefined`, the update will be skipped.
 
 ### Arguments
 
 1. `source` ([_`Store`_]) — Source store, data from this unit passed to `fn`
-2. `clock` ([_`Event`_]) — Trigger event
+2. `clock` ([_`Event`_], [_`Effect`_], [_`Store`_]) — Trigger unit
 3. `fn` `((value: T) => U)` — Transformation function
 
 ### Returns

--- a/src/snapshot/snapshot.fork.test.ts
+++ b/src/snapshot/snapshot.fork.test.ts
@@ -1,4 +1,4 @@
-import { createDomain, allSettled, fork } from 'effector';
+import { createDomain, allSettled, fork, createEvent, createStore } from 'effector';
 import { snapshot } from './index';
 
 test('works in forked scope', async () => {
@@ -73,4 +73,37 @@ test('does not affect original store state', async () => {
 
   expect(scope.getState($copy)).toBe(2);
   expect($copy.getState()).toBe(1);
+});
+
+test('store clock from one scope does not affect another', async () => {
+  const app = createDomain();
+
+  const updateOriginal = createEvent<string>({ domain: app });
+  const updateTrigger = createEvent<void>({ domain: app });
+
+  const $original = createStore('first', { domain: app }).on(
+    updateOriginal,
+    (_, newValue) => newValue,
+  );
+
+  const $trigger = createStore(0, { domain: app }).on(
+    updateTrigger,
+    (state) => state + 1,
+  );
+
+  const $copy = snapshot({ source: $original, clock: $trigger });
+
+  const scope1 = fork(app);
+  const scope2 = fork(app);
+
+  expect(scope1.getState($copy)).toBe('first');
+  expect(scope2.getState($copy)).toBe('first');
+
+  await allSettled(updateOriginal, { scope: scope1, params: 'second' });
+  await allSettled(updateOriginal, { scope: scope2, params: 'second' });
+
+  await allSettled(updateTrigger, { scope: scope1 });
+
+  expect(scope1.getState($copy)).toBe('second');
+  expect(scope2.getState($copy)).toBe('first');
 });

--- a/test-typings/snapshot.ts
+++ b/test-typings/snapshot.ts
@@ -23,7 +23,7 @@ import { snapshot } from '../src/snapshot';
   expectType<Store<string>>(snapshot({ source: $a }));
 
   const $b = createStore<'a' | 'b'>('a');
-  expectType<Store<number>>(snapshot({ source: $b }));
+  expectType<Store<'a' | 'b'>>(snapshot({ source: $b }));
 }
 
 // Check invalid type for Clock
@@ -53,4 +53,30 @@ import { snapshot } from '../src/snapshot';
 
   // @ts-expect-error
   snapshot({ source: $a, fn: b });
+}
+
+// Check TargetType is not inferred from return value
+{
+  const $a = createStore(0);
+
+  // @ts-expect-error
+  expectType<Store<string>>(snapshot({ source: $a }));
+}
+
+// Check effect is supported as a clock
+{
+  const $a = createStore(0);
+
+  const clock = createEffect();
+
+  expectType<Store<number>>(snapshot({ source: $a, clock }));
+}
+
+// Check store is supported as a clock
+{
+  const $a = createStore(0);
+
+  const $clock = createStore(0);
+
+  expectType<Store<number>>(snapshot({ source: $a, clock: $clock }));
 }


### PR DESCRIPTION
Closes #241 

+ Change `snapshot` types to allow Store or Effect to be used as `clock`
+ Add a `NoInfer` on the return value of `snapshot`

---

- [x] Add tests to `src/snapshot/snapshot.test.ts`
- [x] Add **fork** tests to `src/snapshot/snapshot.fork.test.ts`
- [x] Add **type** tests to `test-typings/snapshot.ts`
- [x] Add documentation in `src/snapshot/readme.md`
  - Added new parameter types to `clock`
