### PR TITLE
Allow to pass void to `delay`

### DIFF
--- a/src/delay/index.ts
+++ b/src/delay/index.ts
@@ -20,7 +20,12 @@ export function delay<T>({
 }: {
   source: Unit<T>;
   timeout: ((_payload: T) => number) | Store<number> | number;
-  target?: Store<T> | Event<T> | Effect<T, any, any>;
+  target?:
+    | Store<T>
+    | Event<T>
+    | Effect<T, any, any>
+    | Event<void>
+    | Effect<void, any, any>;
 }): EventAsReturnType<T> {
   if (!is.unit(source)) throw new TypeError('source must be a unit from effector');
 
@@ -48,12 +53,10 @@ export function delay<T>({
     target: timerFx,
   });
 
-  forward({
-    from: timerFx.doneData,
-    to: target,
-  });
+  // @ts-expect-error
+  forward({ from: timerFx.doneData, to: target });
 
-  return target as unknown as Event<T>;
+  return timerFx.doneData;
 }
 
 function validateTimeout<T>(

--- a/test-typings/delay.ts
+++ b/test-typings/delay.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd';
-import { Event, createStore } from 'effector';
+import { Event, createStore, createEvent, createEffect } from 'effector';
 import { delay } from '../src/delay';
 
 // Check valid type for source
@@ -83,4 +83,20 @@ import { delay } from '../src/delay';
   delay({ source, timeout: createStore(Symbol('example')) });
   // @ts-expect-error
   delay({ source, timeout: createStore(undefined) });
+}
+
+// void events support
+{
+  const source = createEvent<number>();
+  const target = createEvent();
+
+  expectType<Event<number>>(delay({ source, timeout: 100, target }));
+}
+
+// void effects support
+{
+  const source = createEvent<number>();
+  const target = createEffect<void, void>();
+
+  expectType<Event<number>>(delay({ source, timeout: 100, target }));
 }


### PR DESCRIPTION
fixes #235

not sure it's a good idea to hide the problem with ts-expect-error
on the other hand, no idea how to fix public api without it 