### PR TITLE
Allow `combineEvents` to be used in sample directly

### DIFF
--- a/src/combine-events/index.ts
+++ b/src/combine-events/index.ts
@@ -3,6 +3,7 @@ import {
   createStore,
   Effect,
   Event,
+  EventAsReturnType,
   guard,
   is,
   merge,
@@ -36,7 +37,7 @@ type ReturnTarget<Result, Target> = Target extends Store<infer S>
 export function combineEvents<P extends Shape>(config: {
   events: Events<P>;
   reset?: Unit<any>;
-}): Event<P>;
+}): EventAsReturnType<P>;
 
 export function combineEvents<
   P extends Shape,

--- a/test-typings/combine-events.ts
+++ b/test-typings/combine-events.ts
@@ -6,6 +6,7 @@ import {
   createEvent,
   createStore,
   createEffect,
+  sample,
 } from 'effector';
 import { combineEvents } from '../src/combine-events';
 
@@ -259,4 +260,20 @@ import { combineEvents } from '../src/combine-events';
   });
 
   expectType<Effect<Target, void>>(effect);
+}
+
+// Can be used in sample
+{
+  const foo = createEvent<number>();
+  const bar = createEvent<string>();
+
+  sample({
+    clock: combineEvents({
+      events: [foo, bar],
+    }),
+    fn: ([a, b]) => {
+      expectType<number>(a);
+      expectType<string>(b);
+    },
+  });
 }


### PR DESCRIPTION
Closes #273

Current behavior (reproduction): https://tsplay.dev/w25B9W
