### PR TITLE
Implement `once` operator

### DIFF
--- a/src/once/index.ts
+++ b/src/once/index.ts
@@ -1,0 +1,24 @@
+import {
+  Unit,
+  Store,
+  Event,
+  Effect,
+  sample,
+  createStore,
+  EventAsReturnType,
+} from 'effector';
+
+export function once<T>(
+  unit: Event<T> | Effect<T, any, any> | Store<T>,
+): EventAsReturnType<T> {
+  const $canTrigger = createStore<boolean>(true);
+
+  const trigger: Event<T> = sample({
+    clock: unit as Unit<T>,
+    filter: $canTrigger,
+  });
+
+  $canTrigger.on(trigger, () => false);
+
+  return sample({ clock: trigger });
+}

--- a/src/once/once.fork.test.ts
+++ b/src/once/once.fork.test.ts
@@ -1,0 +1,19 @@
+import { allSettled, createEvent, fork, serialize } from 'effector';
+import { once } from './index';
+
+it('persists state between scopes', async () => {
+  const fn = jest.fn();
+
+  const trigger = createEvent<void>();
+  const derived = once(trigger);
+
+  derived.watch(fn);
+
+  const scope1 = fork();
+  await allSettled(trigger, { scope: scope1 });
+
+  const scope2 = fork({ values: serialize(scope1) });
+  await allSettled(trigger, { scope: scope2 });
+
+  expect(fn).toHaveBeenCalledTimes(1);
+});

--- a/src/once/once.test.ts
+++ b/src/once/once.test.ts
@@ -1,0 +1,88 @@
+import { createEffect, createEvent, createStore, is, launch } from 'effector';
+import { once } from './index';
+
+it('should source only once', () => {
+  const fn = jest.fn();
+
+  const source = createEvent<void>();
+  const derived = once(source);
+
+  derived.watch(fn);
+  expect(fn).toHaveBeenCalledTimes(0);
+
+  source();
+  source();
+
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+
+it('supports effect as an argument', () => {
+  const fn = jest.fn();
+
+  const triggerFx = createEffect<void, void>(jest.fn());
+  const derived = once(triggerFx);
+
+  derived.watch(fn);
+  expect(fn).toHaveBeenCalledTimes(0);
+
+  triggerFx();
+
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+
+it('supports store as an argument', () => {
+  const fn = jest.fn();
+
+  const increment = createEvent<void>();
+  const $source = createStore<number>(0).on(increment, (n) => n + 1);
+  const derived = once($source);
+
+  derived.watch(fn);
+  expect(fn).toHaveBeenCalledTimes(0);
+
+  increment();
+
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+
+it('always returns event', () => {
+  const event = createEvent<string>();
+  const effect = createEffect<string, void>();
+  const $store = createStore<string>('');
+
+  expect(is.event(once(event))).toBe(true);
+  expect(is.event(once(effect))).toBe(true);
+  expect(is.event(once($store))).toBe(true);
+});
+
+it('only triggers once in race conditions', () => {
+  const fn = jest.fn();
+
+  const source = createEvent<string>();
+  const derived = once(source);
+
+  derived.watch(fn);
+  expect(fn).toHaveBeenCalledTimes(0);
+
+  launch({
+    target: [source, source],
+    params: ['a', 'b'],
+  });
+
+  expect(fn).toHaveBeenCalledTimes(1);
+});
+
+it('calling derived event does not lock once', () => {
+  const fn = jest.fn();
+
+  const source = createEvent<void>();
+  const derived = once(source);
+
+  derived.watch(fn);
+  expect(fn).toHaveBeenCalledTimes(0);
+
+  derived();
+  source();
+
+  expect(fn).toHaveBeenCalledTimes(2);
+});

--- a/src/once/readme.md
+++ b/src/once/readme.md
@@ -1,0 +1,55 @@
+# once
+
+```ts
+import { once } from 'patronum';
+// or
+import { once } from 'patronum/once';
+```
+
+### Motivation
+
+The method allows to do something only on the first ever trigger of `source`.
+It is useful to trigger effects or other logic only once per application's lifetime.
+
+### Formulae
+
+```ts
+target = once(source);
+```
+
+- When `source` is triggered, launch `target` with data from `source`, but only once.
+
+### Arguments
+
+- `source` `(Event<T>` | `Effect<T>` | `Store<T>)` — Source unit, data from this unit is used by `target`.
+
+### Returns
+
+- `target` `Event<T>` — The event that will be triggered exactly once after `source` is triggered.
+
+### Example
+
+```ts
+const messageReceived = createEvent<string>();
+const firstMessageReceived = once(messageReceived);
+
+firstMessageReceived.watch((message) =>
+  console.log('First message received:', message),
+);
+
+messageReceived('Hello'); // First message received: Hello
+messageReceived('World');
+```
+
+#### Alternative
+
+```ts
+import { createGate } from 'effector-react';
+
+const PageGate = createGate();
+
+sample({
+  source: once(PageGate.open),
+  target: fetchDataFx,
+});
+```

--- a/test-typings/once.ts
+++ b/test-typings/once.ts
@@ -1,0 +1,31 @@
+import { expectType } from 'tsd';
+import {
+  Event,
+  createStore,
+  createEvent,
+  createEffect,
+  createDomain,
+  fork,
+} from 'effector';
+import { once } from '../src/once';
+
+// Supports Event, Effect and Store as an argument
+{
+  expectType<Event<string>>(once(createEvent<string>()));
+  expectType<Event<string>>(once(createEffect<string, void>()));
+  expectType<Event<string>>(once(createStore<string>('')));
+}
+
+// Does not allow scope or domain as a first argument
+{
+  // @ts-expect-error
+  once(createDomain());
+  // @ts-expect-error
+  once(fork());
+}
+
+// Correctly passes through complex types
+{
+  const source = createEvent<'string' | false>();
+  expectType<Event<'string' | false>>(once(source));
+}


### PR DESCRIPTION
### Description

This method allows you to do something only once upon `source` trigger. Simple QoL operator that helps run some logic one time only.

```ts
target = once(source)
```

Cases where the operator might be used:
- Gate triggering some `fetchFx` only on the first render. See https://github.com/effector/effector/issues/858
- Getting an initial value based on some frequently-triggered event.
  ```ts
  const $initialMousePosition = createStore(null)
  const mouseMoved = createEvent()

  document.addEventListener("mousemove", mouseMoved)

  sample({
    source: once(mouseMoved),
    target: $initialMousePosition
  })
  ```

### Checklist for a new method

- [x] Create a directory for the new method in the `src` directory in `param-case`
- [x] Place the source code to `src/method-name/index.ts` in ESModules export in `camelCase` **named** export
- [x] Add tests to `src/method-name/method-name.test.ts`
- [x] Add **fork** tests to `src/method-name/method-name.fork.test.ts`
- [x] Add **type** tests to `test-typings/method-name.ts`
  - Use `// @ts-expect-error` to mark expected type error
  - `import { expectType } from 'tsd'` to check expected return type
- [x] Add documentation in `src/method-name/readme.md`
  - Add header `Patronum/MethodName`
  - Add section with overloads, if have
  - Add `Motivation`, `Formulae`, `Arguments` and `Return` sections for each overload
  - Add useful examples in `Example` section for each overload
