### PR TITLE
Support `@@trigger` protocol in operator `interval`

### DIFF
--- a/src/interval/index.ts
+++ b/src/interval/index.ts
@@ -9,13 +9,7 @@ import {
   is,
 } from 'effector';
 
-export function interval<S extends unknown, F extends unknown>({
-  timeout,
-  start,
-  stop,
-  leading = false,
-  trailing = false,
-}: {
+export function interval<S extends unknown, F extends unknown>(config: {
   timeout: number | Store<number>;
   start: Event<S>;
   stop?: Event<F>;
@@ -23,11 +17,7 @@ export function interval<S extends unknown, F extends unknown>({
   trailing?: boolean;
 }): { tick: Event<void>; isRunning: Store<boolean> };
 
-export function interval({
-  timeout,
-  leading = false,
-  trailing = false,
-}: {
+export function interval(config: {
   timeout: number | Store<number>;
   leading?: boolean;
   trailing?: boolean;

--- a/src/interval/interval.fork.test.ts
+++ b/src/interval/interval.fork.test.ts
@@ -1,4 +1,11 @@
-import { allSettled, createEvent, fork, createStore, guard } from 'effector';
+import {
+  allSettled,
+  createEvent,
+  fork,
+  createStore,
+  guard,
+  createWatch,
+} from 'effector';
 import { argumentHistory, wait, watch } from '../../test-library';
 import { interval } from '.';
 
@@ -95,4 +102,31 @@ test('does not leaves unresolved timeout effect, if stopped', async () => {
   await allSettled(start, { scope });
 
   expect(scope.getState($count)).toEqual(6);
+});
+
+describe('@@trigger', () => {
+  test('fire tick on start and stop after teardown', async () => {
+    const listener = jest.fn();
+    const intervalTrigger = interval({ timeout: 1 });
+
+    const scope = fork();
+
+    const unwatch = createWatch({
+      unit: intervalTrigger['@@trigger'].fired,
+      fn: listener,
+      scope,
+    });
+
+    allSettled(intervalTrigger['@@trigger'].setup, { scope });
+
+    await wait(1);
+    expect(listener).toBeCalledTimes(1);
+
+    await allSettled(intervalTrigger['@@trigger'].teardown, { scope });
+
+    await wait(10);
+    expect(listener).toBeCalledTimes(1);
+
+    unwatch();
+  });
 });

--- a/src/interval/readme.md
+++ b/src/interval/readme.md
@@ -78,3 +78,27 @@ setTimeout(() => stopCounter(), 5000);
 ```
 
 [Try it](https://share.effector.dev/EOVzc3df)
+
+### `@@trigger` protocol
+
+`interval` supports [`@@trigger` protocol](https://withease.pages.dev/protocols/trigger.html). It means that you can use `interval` whatever you can use `trigger` with, just do not pass `start` and `stop` options.
+
+```ts
+import { interval } from 'patronum';
+
+somethingThatRequiresTrigger({
+  trigger: interval({ timeout: 1000 }),
+});
+```
+
+For example, you can use `interval` to refresh data in the Query from the library [Farfetched](https://farfetched.pages.dev/tutorial/trigger_api.html#external-triggers) using `@@trigger` protocol.
+
+```ts
+import { keepFresh } from '@farfetched/core';
+import { interval } from 'patronum';
+
+keepFresh(someQuery, {
+  // 👇 Query will be refreshed each 1000 ms
+  triggers: [interval({ timeout: 1000 })],
+});
+```

--- a/test-typings/interval.ts
+++ b/test-typings/interval.ts
@@ -38,23 +38,21 @@ import { interval } from '../src/interval';
     }),
   );
 
+  // @ts-expect-error
   interval({
     timeout: 100,
     start: createEvent<void>(),
     stop: createEvent<void>(),
-    // @ts-expect-error
     leading: 1,
-    // @ts-expect-error
     trailing: '',
   });
 
+  // @ts-expect-error
   interval({
     timeout: 100,
     start: createEvent<void>(),
     stop: createEvent<void>(),
-    // @ts-expect-error
     leading: [],
-    // @ts-expect-error
     trailing: null,
   });
 }


### PR DESCRIPTION
After this change, users of [Farfetched](https://farfetched.pages.dev/tutorial/trigger_api.html#external-triggers) would get an ability to refresh theirs Queries with the `interval` operator. The protocol itself is [defined in With Ease](https://withease.pages.dev/protocols/trigger.html).