### PR TITLE
fix: replace "in" with "hasOwnProperty" in reshape's for in

### DIFF
--- a/src/reshape/index.ts
+++ b/src/reshape/index.ts
@@ -18,13 +18,15 @@ export function reshape<Type, Shape extends Record<string, unknown>>({
   const result: Record<string, Store<any>> = {};
 
   for (const key in shape) {
-    if (key in shape) {
-      const fn = shape[key];
-      result[key] = source.map((state) => {
-        const result = fn(state);
-        return result === undefined ? null : result;
-      });
+    if (!Object.prototype.hasOwnProperty.call(shape, key)) {
+      continue;
     }
+
+    const fn = shape[key];
+    result[key] = source.map((state) => {
+      const result = fn(state);
+      return result === undefined ? null : result;
+    });
   }
 
   return result as any;

--- a/src/reshape/reshape.test.ts
+++ b/src/reshape/reshape.test.ts
@@ -1,4 +1,4 @@
-import { createStore, createEvent } from 'effector';
+import { createEvent, createStore } from 'effector';
 import { reshape } from './index';
 
 test('reshape from string to different types', () => {
@@ -73,4 +73,23 @@ test('reshape returns null in shape if fn returned undefined', () => {
 
   expect(shape.first.getState()).toBe('');
   expect(shape.second.getState()).toBe(null);
+});
+
+test("reshape ignores shape's prototype properties", () => {
+  type User = { first: string; second?: number };
+
+  const $user = createStore<User>({ first: '' });
+
+  const shape = {
+    first: (user: User) => user.first,
+  };
+
+  Object.setPrototypeOf(shape, { second: (user: User) => user.second });
+
+  const stores = reshape({
+    source: $user,
+    shape,
+  });
+
+  expect(stores).not.toHaveProperty('second');
 });


### PR DESCRIPTION
Replace "in" with "hasOwnProperty" in reshape's for in

"in" checks if object has direct OR inherited property just like "for in" do. So using "in" in "for in" doesn't make sense. This PR replace "in" condition with "hasOwnProperty" that checks only if direct property exists. 

I used Object's prototype hasOwnProperty method just in case because [not all object have hasOwnProperty method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty#using_hasownproperty_as_a_property_name)