### PR TITLE
Add skipVoid to maps and combines

### DIFF
--- a/src/and/index.ts
+++ b/src/and/index.ts
@@ -1,12 +1,16 @@
 import { combine, Store } from 'effector';
 
 export function and(...stores: Array<Store<any>>): Store<boolean> {
-  return combine(stores, (values) => {
-    for (const value of values) {
-      if (!value) {
-        return false;
+  return combine(
+    stores,
+    (values) => {
+      for (const value of values) {
+        if (!value) {
+          return false;
+        }
       }
-    }
-    return true;
-  }) as Store<boolean>;
+      return true;
+    },
+    { skipVoid: true },
+  ) as Store<boolean>;
 }

--- a/src/and/index.ts
+++ b/src/and/index.ts
@@ -11,6 +11,6 @@ export function and(...stores: Array<Store<any>>): Store<boolean> {
       }
       return true;
     },
-    { skipVoid: true },
+    { skipVoid: false },
   ) as Store<boolean>;
 }

--- a/src/combine-events/index.ts
+++ b/src/combine-events/index.ts
@@ -96,7 +96,7 @@ export function combineEvents<P>({
 
     sample({
       source: eventsTrriggered,
-      filter: $counter.map((value) => value === 0, { skipVoid: true }),
+      filter: $counter.map((value) => value === 0, { skipVoid: false }),
       target: target as UnitTargetable<any>,
     });
   });

--- a/src/combine-events/index.ts
+++ b/src/combine-events/index.ts
@@ -96,7 +96,7 @@ export function combineEvents<P>({
 
     sample({
       source: eventsTrriggered,
-      filter: $counter.map((value) => value === 0),
+      filter: $counter.map((value) => value === 0, { skipVoid: true }),
       target: target as UnitTargetable<any>,
     });
   });

--- a/src/condition/index.ts
+++ b/src/condition/index.ts
@@ -130,7 +130,7 @@ function inverse<A extends boolean, T>(
   fnOrUnit: Store<boolean> | ((payload: T) => boolean),
 ): Store<boolean> | ((payload: T) => boolean) {
   if (is.unit(fnOrUnit)) {
-    return fnOrUnit.map((value) => !value, { skipVoid: true });
+    return fnOrUnit.map((value) => !value, { skipVoid: false });
   }
   return (value) => !fnOrUnit(value);
 }

--- a/src/condition/index.ts
+++ b/src/condition/index.ts
@@ -1,4 +1,14 @@
-import { createEvent, Effect, Event, sample, is, Store, Unit, UnitTargetable, split } from 'effector';
+import {
+  createEvent,
+  Effect,
+  Event,
+  sample,
+  is,
+  Store,
+  Unit,
+  UnitTargetable,
+  split,
+} from 'effector';
 
 type NoInfer<T> = T & { [K in keyof T]: T[K] };
 type EventAsReturnType<Payload> = any extends Payload ? Event<Payload> : never;
@@ -120,7 +130,7 @@ function inverse<A extends boolean, T>(
   fnOrUnit: Store<boolean> | ((payload: T) => boolean),
 ): Store<boolean> | ((payload: T) => boolean) {
   if (is.unit(fnOrUnit)) {
-    return fnOrUnit.map((value) => !value);
+    return fnOrUnit.map((value) => !value, { skipVoid: true });
   }
   return (value) => !fnOrUnit(value);
 }

--- a/src/either/index.ts
+++ b/src/either/index.ts
@@ -64,6 +64,7 @@ export function either<Then, Other>(
       then as Store<Then>,
       other as Store<Other>,
       (filter, then, other) => (filter ? then : other),
+      { skipVoid: true },
     );
   }
 

--- a/src/either/index.ts
+++ b/src/either/index.ts
@@ -64,7 +64,7 @@ export function either<Then, Other>(
       then as Store<Then>,
       other as Store<Other>,
       (filter, then, other) => (filter ? then : other),
-      { skipVoid: true },
+      { skipVoid: false },
     );
   }
 

--- a/src/empty/index.ts
+++ b/src/empty/index.ts
@@ -1,5 +1,5 @@
 import { Store } from 'effector';
 
 export function empty<A>(source: Store<A | null | undefined>): Store<boolean> {
-  return source.map((value) => value == null);
+  return source.map((value) => value == null, { skipVoid: true });
 }

--- a/src/empty/index.ts
+++ b/src/empty/index.ts
@@ -1,5 +1,5 @@
 import { Store } from 'effector';
 
 export function empty<A>(source: Store<A | null | undefined>): Store<boolean> {
-  return source.map((value) => value == null, { skipVoid: true });
+  return source.map((value) => value == null, { skipVoid: false });
 }

--- a/src/equals/index.ts
+++ b/src/equals/index.ts
@@ -25,5 +25,7 @@ export function equals<A, B>(
     ? B
     : { error: 'argument b should extends a' },
 ): Store<boolean> {
-  return combine(a as Store<A>, b as Store<A>, (a, b) => a === b, { skipVoid: true });
+  return combine(a as Store<A>, b as Store<A>, (a, b) => a === b, {
+    skipVoid: false,
+  });
 }

--- a/src/equals/index.ts
+++ b/src/equals/index.ts
@@ -25,5 +25,5 @@ export function equals<A, B>(
     ? B
     : { error: 'argument b should extends a' },
 ): Store<boolean> {
-  return combine(a as Store<A>, b as Store<A>, (a, b) => a === b);
+  return combine(a as Store<A>, b as Store<A>, (a, b) => a === b, { skipVoid: true });
 }

--- a/src/every/index.ts
+++ b/src/every/index.ts
@@ -51,7 +51,9 @@ export function every<T>(
   if (isFunction(predicate)) {
     checker = predicate;
   } else if (is.store(predicate)) {
-    checker = predicate.map((value) => (required: T) => value === required);
+    checker = predicate.map((value) => (required: T) => value === required, {
+      skipVoid: true,
+    });
   } else {
     checker = (value: T) => value === predicate;
   }
@@ -60,7 +62,9 @@ export function every<T>(
   // Combine pass simple values as is
   const $checker = checker as Store<(value: T) => boolean>;
 
-  return combine($checker, $values, (checker, values) => values.every(checker));
+  return combine($checker, $values, (checker, values) => values.every(checker), {
+    skipVoid: true,
+  });
 }
 
 function isFunction<T>(value: unknown): value is (value: T) => boolean {

--- a/src/every/index.ts
+++ b/src/every/index.ts
@@ -52,7 +52,7 @@ export function every<T>(
     checker = predicate;
   } else if (is.store(predicate)) {
     checker = predicate.map((value) => (required: T) => value === required, {
-      skipVoid: true,
+      skipVoid: false,
     });
   } else {
     checker = (value: T) => value === predicate;
@@ -63,7 +63,7 @@ export function every<T>(
   const $checker = checker as Store<(value: T) => boolean>;
 
   return combine($checker, $values, (checker, values) => values.every(checker), {
-    skipVoid: true,
+    skipVoid: false,
   });
 }
 

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -15,16 +15,19 @@ export function format<Values extends StoreOrValue<any>[]>(
   strings: TemplateStringsArray,
   ...stores: [...Values]
 ): Store<string> {
-  return combine(stores, (stores) =>
-    strings.reduce(
-      (acc, value, index) =>
-        acc.concat(
-          isLastElement(strings, index)
-            ? value
-            : `${value}${toString(stores[index])}`,
-        ),
-      '',
-    ),
+  return combine(
+    stores,
+    (stores) =>
+      strings.reduce(
+        (acc, value, index) =>
+          acc.concat(
+            isLastElement(strings, index)
+              ? value
+              : `${value}${toString(stores[index])}`,
+          ),
+        '',
+      ),
+    { skipVoid: true },
   );
 }
 

--- a/src/format/index.ts
+++ b/src/format/index.ts
@@ -27,7 +27,7 @@ export function format<Values extends StoreOrValue<any>[]>(
           ),
         '',
       ),
-    { skipVoid: true },
+    { skipVoid: false },
   );
 }
 

--- a/src/in-flight/index.ts
+++ b/src/in-flight/index.ts
@@ -22,5 +22,6 @@ export function inFlight({
   return combine(
     effects!.map((fx) => fx.inFlight),
     (inFlights) => inFlights.reduce((all, current) => all + current, 0),
+    { skipVoid: true },
   );
 }

--- a/src/in-flight/index.ts
+++ b/src/in-flight/index.ts
@@ -22,6 +22,6 @@ export function inFlight({
   return combine(
     effects!.map((fx) => fx.inFlight),
     (inFlights) => inFlights.reduce((all, current) => all + current, 0),
-    { skipVoid: true },
+    { skipVoid: false },
   );
 }

--- a/src/interval/index.ts
+++ b/src/interval/index.ts
@@ -34,7 +34,7 @@ export function interval<S extends unknown, F extends unknown>({
   const $isRunning = createStore(false);
   const $timeout = toStoreNumber(timeout);
 
-  const $notRunning = $isRunning.map((running) => !running, { skipVoid: true });
+  const $notRunning = $isRunning.map((running) => !running, { skipVoid: false });
 
   const saveTimeout = createEvent<{
     timeoutId: NodeJS.Timeout;

--- a/src/interval/index.ts
+++ b/src/interval/index.ts
@@ -1,12 +1,4 @@
-import {
-  Event,
-  Store,
-  createEvent,
-  createStore,
-  sample,
-  attach,
-  is,
-} from 'effector';
+import { Event, Store, createEvent, createStore, sample, attach, is } from 'effector';
 
 export function interval<S extends unknown, F extends unknown>(config: {
   timeout: number | Store<number>;
@@ -42,7 +34,7 @@ export function interval<S extends unknown, F extends unknown>({
   const $isRunning = createStore(false);
   const $timeout = toStoreNumber(timeout);
 
-  const $notRunning = $isRunning.map((running) => !running);
+  const $notRunning = $isRunning.map((running) => !running, { skipVoid: true });
 
   const saveTimeout = createEvent<{
     timeoutId: NodeJS.Timeout;

--- a/src/not/index.ts
+++ b/src/not/index.ts
@@ -1,5 +1,5 @@
 import { Store } from 'effector';
 
 export function not<T extends unknown>(source: Store<T>): Store<boolean> {
-  return source.map((value) => !value, { skipVoid: true });
+  return source.map((value) => !value, { skipVoid: false });
 }

--- a/src/not/index.ts
+++ b/src/not/index.ts
@@ -1,5 +1,5 @@
 import { Store } from 'effector';
 
 export function not<T extends unknown>(source: Store<T>): Store<boolean> {
-  return source.map((value) => !value);
+  return source.map((value) => !value, { skipVoid: true });
 }

--- a/src/or/index.ts
+++ b/src/or/index.ts
@@ -1,12 +1,16 @@
 import { combine, Store } from 'effector';
 
 export function or(...stores: Array<Store<any>>): Store<boolean> {
-  return combine(stores, (values) => {
-    for (const value of values) {
-      if (value) {
-        return true;
+  return combine(
+    stores,
+    (values) => {
+      for (const value of values) {
+        if (value) {
+          return true;
+        }
       }
-    }
-    return false;
-  }) as Store<boolean>;
+      return false;
+    },
+    { skipVoid: true },
+  ) as Store<boolean>;
 }

--- a/src/or/index.ts
+++ b/src/or/index.ts
@@ -11,6 +11,6 @@ export function or(...stores: Array<Store<any>>): Store<boolean> {
       }
       return false;
     },
-    { skipVoid: true },
+    { skipVoid: false },
   ) as Store<boolean>;
 }

--- a/src/pending/index.ts
+++ b/src/pending/index.ts
@@ -40,6 +40,6 @@ export function pending({
   return combine(
     effects.map((fx) => fx.pending),
     strategy,
-    { skipVoid: true },
+    { skipVoid: false },
   );
 }

--- a/src/pending/index.ts
+++ b/src/pending/index.ts
@@ -40,5 +40,6 @@ export function pending({
   return combine(
     effects.map((fx) => fx.pending),
     strategy,
+    { skipVoid: true },
   );
 }

--- a/src/reshape/index.ts
+++ b/src/reshape/index.ts
@@ -28,7 +28,7 @@ export function reshape<Type, Shape extends Record<string, unknown>>({
         const result = fn(state);
         return result === undefined ? null : result;
       },
-      { skipVoid: true },
+      { skipVoid: false },
     );
   }
 

--- a/src/reshape/index.ts
+++ b/src/reshape/index.ts
@@ -23,10 +23,13 @@ export function reshape<Type, Shape extends Record<string, unknown>>({
     }
 
     const fn = shape[key];
-    result[key] = source.map((state) => {
-      const result = fn(state);
-      return result === undefined ? null : result;
-    });
+    result[key] = source.map(
+      (state) => {
+        const result = fn(state);
+        return result === undefined ? null : result;
+      },
+      { skipVoid: true },
+    );
   }
 
   return result as any;

--- a/src/some/index.ts
+++ b/src/some/index.ts
@@ -49,7 +49,7 @@ export function some<T>(
     checker = predicate;
   } else if (is.store(predicate)) {
     checker = predicate.map((value) => (required: T) => value === required, {
-      skipVoid: true,
+      skipVoid: false,
     });
   } else {
     checker = (value: T) => value === predicate;
@@ -60,7 +60,7 @@ export function some<T>(
   const $checker = checker as Store<(value: T) => boolean>;
 
   return combine($checker, $values, (checker, values) => values.some(checker), {
-    skipVoid: true,
+    skipVoid: false,
   });
 }
 

--- a/src/some/index.ts
+++ b/src/some/index.ts
@@ -48,7 +48,9 @@ export function some<T>(
   if (isFunction(predicate)) {
     checker = predicate;
   } else if (is.store(predicate)) {
-    checker = predicate.map((value) => (required: T) => value === required);
+    checker = predicate.map((value) => (required: T) => value === required, {
+      skipVoid: true,
+    });
   } else {
     checker = (value: T) => value === predicate;
   }
@@ -57,7 +59,9 @@ export function some<T>(
   // Combine pass simple values as is
   const $checker = checker as Store<(value: T) => boolean>;
 
-  return combine($checker, $values, (checker, values) => values.some(checker));
+  return combine($checker, $values, (checker, values) => values.some(checker), {
+    skipVoid: true,
+  });
 }
 
 function isFunction<T>(value: unknown): value is (value: T) => boolean {


### PR DESCRIPTION
If we add lazy computations, it will works only with explicit skipVoid: false because it makes computed stores really stateless