### PR TITLE
Set effector version strictly to 23

### DIFF
--- a/scripts/source.package.js
+++ b/scripts/source.package.js
@@ -20,6 +20,6 @@ module.exports = () => ({
   },
   homepage: 'https://github.com/effector/patronum#readme',
   peerDependencies: {
-    effector: '^22.8.8 || ^23',
+    effector: '^23',
   },
 });


### PR DESCRIPTION
Due to use of `batch` and `skipVoid`, patronum cannot be compatible with effector 22 