### PR TITLE
Remove redundant `sample` in `once`

### DIFF
--- a/src/once/index.ts
+++ b/src/once/index.ts
@@ -39,5 +39,5 @@ export function once<T>(
     $canTrigger.reset(reset);
   }
 
-  return sample({ clock: trigger });
+  return trigger
 }

--- a/test-typings/once.ts
+++ b/test-typings/once.ts
@@ -4,8 +4,6 @@ import {
   createStore,
   createEvent,
   createEffect,
-  createDomain,
-  fork,
 } from 'effector';
 import { once } from '../dist/once';
 


### PR DESCRIPTION
With `effector@23` calling a derived `Unit` is an error, so a `sample` that guarded that behavior is no longer required.