### PR TITLE
Simplify `condition` types

### DIFF
--- a/test-typings/condition.ts
+++ b/test-typings/condition.ts
@@ -6,6 +6,7 @@ import {
   createStore,
   Effect,
   Event,
+  EventCallable,
   Store,
 } from 'effector';
 import { condition } from '../dist/condition';
@@ -220,25 +221,25 @@ import { condition } from '../dist/condition';
   );
 }
 
-// Disallow pass invalid type to then/else
+// Disallow pass invalid type to then/else/if
 {
   condition({
-    // @ts-expect-error
     source: createStore(0),
     if: 0,
+    // @ts-expect-error 'string' is not assignable to 'number | void'
     then: createEvent<string>(),
   });
 
   condition({
-    // @ts-expect-error
     source: createStore<boolean>(false),
+    // @ts-expect-error 'Console' is not assignable to `if`
     if: console,
     then: createEvent(),
   });
 
   condition({
-    // @ts-expect-error
     source: createStore<string>(''),
+    // @ts-expect-error 'number' is not assignable to type 'boolean'
     if: (a) => 1,
     then: createEvent(),
   });
@@ -257,5 +258,127 @@ import { condition } from '../dist/condition';
     if: boolStore,
     then: fxVoid,
     else: fxOtherVoid,
+  });
+}
+
+// allows nesting conditions
+{
+  condition({
+    source: createEvent<'a' | 'b' | 1>(),
+    if: (value): value is 'a' | 'b' => typeof value === 'string',
+    then: condition<'a' | 'b'>({
+      if: () => true,
+      then: createEvent<'a'>(),
+      else: createEvent<'b'>(),
+    }),
+  });
+}
+
+// returns `typeof source` when source is provided
+{
+  const source = createEvent<string | number>();
+
+  expectType<typeof source>(
+    condition({
+      source,
+      if: 'string?',
+      then: createEvent<void>(),
+    }),
+  );
+}
+
+// Correctly passes type to `if`
+{
+  condition({
+    source: createEvent<string>(),
+    if: (payload) => (expectType<string>(payload), true),
+    then: createEvent<string>(),
+  });
+
+  condition({
+    source: createEvent<'complex' | 'type'>(),
+    if: (payload) => (expectType<'complex' | 'type'>(payload), true),
+    then: createEvent<void>(),
+  });
+
+  condition({
+    source: createEvent<string>(),
+    // @ts-expect-error 'string' is not assignable to type 'number'
+    if: (_: number) => true,
+    then: createEvent<void>(),
+  });
+}
+
+// `Boolean` as type guard: disallows invalid type in `then`
+{
+  condition({
+    source: createEvent<string | null>(),
+    if: Boolean,
+    // @ts-expect-error 'number' is not assignable to type 'string | void'
+    then: createEvent<number>(),
+  });
+}
+
+// `Boolean` as type guard: disallows invalid type in then/else
+{
+  condition({
+    source: createEvent<string | null>(),
+    if: Boolean,
+    // @ts-expect-error 'number' is not assignable to type 'string | void'
+    then: createEvent<number>(),
+  });
+
+  condition({
+    source: createEvent<string | null>(),
+    if: Boolean,
+    // @ts-expect-error 'number' is not assignable to type 'string | void'
+    else: createEvent<number>(),
+  });
+}
+
+// `Boolean` as type guard: works for all sources
+{
+  expectType<EventCallable<string | null>>(
+    condition({
+      source: createEvent<string | null>(),
+      if: Boolean,
+      then: createEvent<string>(),
+      else: createEvent<null>(),
+    }),
+  );
+
+  expectType<EventCallable<string | null>>(
+    condition({
+      source: createStore<string | null>(null),
+      if: Boolean,
+      then: createEvent<string>(),
+      else: createEvent<null>(),
+    }),
+  );
+
+  expectType<EventCallable<string | null>>(
+    condition({
+      source: createEffect<string | null, void>(),
+      if: Boolean,
+      then: createEvent<string>(),
+      else: createEvent<null>(),
+    }),
+  );
+}
+
+// `Boolean` as type guard: disallows invalid type in then/else
+{
+  condition({
+    source: createEvent<string | null>(),
+    if: Boolean,
+    // @ts-expect-error
+    then: createEvent<number>(),
+  });
+
+  condition({
+    source: createEvent<string | null>(),
+    if: Boolean,
+    // @ts-expect-error
+    else: createEvent<number>(),
   });
 }


### PR DESCRIPTION
Related #184
Closes #185 #109

This PR aims to simplify and shorten some of the overloads of `condition`. This only changes types, and does not touch runtime.

1. Added explicit support for type guards (with a new overload)
2. I've added `Boolean` as a supported type guard
3. Simplified types by merging separate `Event`, `Effect` and `Store` in `source` into a single type

All existing type tests pass. I've also added a couple of new type tests.

In future this may allow to add `clock` or `fn` to `condition`, as types are more manageable now