### PR TITLE
feat(splitMap):  added targets field

### DIFF
--- a/src/split-map/index.ts
+++ b/src/split-map/index.ts
@@ -1,36 +1,77 @@
-import { Event, is, Store, Unit } from 'effector';
+import { Event, Tuple, Unit, UnitTargetable, is, sample } from 'effector';
+
+type TargetUnits<T> =
+  | UnitTargetable<T | void>
+  | Tuple<UnitTargetable<T | void>>
+  | ReadonlyArray<UnitTargetable<T | void>>;
+
+const hasPropBase = {}.hasOwnProperty;
+const hasOwnProp = <O extends { [k: string]: unknown }>(object: O, key: string) =>
+  hasPropBase.call(object, key);
 
 export function splitMap<
   S,
   Cases extends Record<string, (payload: S) => any | undefined>,
+  Targets extends {
+    [K in keyof Cases]?: Cases[K] extends (s: S) => infer R
+      ? Targets[K] extends TargetUnits<infer TargetType>
+        ? Exclude<R, undefined> extends TargetType
+          ? TargetUnits<TargetType>
+          : TargetUnits<Exclude<R, undefined>>
+        : TargetUnits<Exclude<R, undefined>>
+      : never;
+  } & { __?: TargetUnits<S> },
 >({
   source,
   cases,
+  targets,
 }: {
   source: Unit<S>;
   cases: Cases;
+  targets?: Targets;
 }): {
   [K in keyof Cases]: Cases[K] extends (p: S) => infer R
     ? Event<Exclude<R, undefined>>
     : never;
 } & { __: Event<S> } {
-  const result: Record<string, Event<any> | Store<any>> = {};
+  const result: Record<string, Event<any>> = {};
 
   let current = is.store(source) ? source.updates : (source as Event<S>);
 
   for (const key in cases) {
-    if (key in cases) {
+    if (hasOwnProp(cases, key)) {
       const fn = cases[key];
 
-      result[key] = current.filterMap(fn);
+      const caseEvent = current.filterMap(fn);
+
+      result[key] = caseEvent;
+
       current = current.filter({
         fn: (data) => !fn(data),
       });
+
+      if (targets && hasOwnProp(targets, key)) {
+        const currentTarget = targets[key];
+
+        sample({
+          clock: caseEvent,
+          target: currentTarget as UnitTargetable<any>,
+        });
+      }
     }
   }
 
   // eslint-disable-next-line no-underscore-dangle
   result.__ = current;
+
+  if (targets && '__' in targets) {
+    const defaultCaseTarget = targets.__;
+
+    sample({
+      clock: current,
+      target: defaultCaseTarget as UnitTargetable<any>,
+    });
+  }
 
   return result as any;
 }

--- a/src/split-map/split-map.fork.test.ts
+++ b/src/split-map/split-map.fork.test.ts
@@ -1,19 +1,31 @@
 import 'regenerator-runtime/runtime';
-import { createDomain, fork, serialize, allSettled } from 'effector';
+import {
+  createDomain,
+  fork,
+  allSettled,
+  createEvent,
+  createStore,
+  createApi,
+} from 'effector';
 
 import { splitMap } from './index';
 
 test('works in forked scope', async () => {
-  const app = createDomain();
-  const source = app.createEvent<{ first?: number; another?: boolean }>();
+  const $target = createStore(0);
+
+  const source = createEvent<{ first?: number; another?: boolean }>();
   const out = splitMap({
     source,
     cases: {
       first: (payload) => payload.first,
     },
+    targets: {
+      first: $target,
+      __: createApi($target, { another: (state) => -state }).another,
+    },
   });
 
-  const $data = app.createStore(0);
+  const $data = createStore(0);
 
   $data
     .on(out.first, (state, payload) => state + payload)
@@ -25,30 +37,29 @@ test('works in forked scope', async () => {
     scope,
     params: { first: 15 },
   });
-  expect(serialize(scope)).toMatchInlineSnapshot(`
-    {
-      "xwy4bm": 15,
-    }
-  `);
+  expect(scope.getState($data)).toBe(15);
+  expect(scope.getState($target)).toBe(15);
 
   await allSettled(source, {
     scope,
     params: { another: true },
   });
-  expect(serialize(scope)).toMatchInlineSnapshot(`
-    {
-      "xwy4bm": -15,
-    }
-  `);
+  expect(scope.getState($data)).toBe(-15);
+  expect(scope.getState($target)).toBe(-15);
 });
 
 test('do not affect another fork', async () => {
+  const $target = createStore(0);
+
   const app = createDomain();
   const source = app.createEvent<{ first?: number; another?: boolean }>();
   const out = splitMap({
     source,
     cases: {
       first: (payload) => payload.first,
+    },
+    targets: {
+      first: $target,
     },
   });
 
@@ -65,30 +76,29 @@ test('do not affect another fork', async () => {
     scope: scopeA,
     params: { first: 200 },
   });
-  expect(serialize(scopeA)).toMatchInlineSnapshot(`
-    {
-      "l4dkuf": 200,
-    }
-  `);
+  expect(scopeA.getState($data)).toBe(200);
+  expect(scopeA.getState($target)).toBe(200);
 
   await allSettled(source, {
     scope: scopeB,
     params: { first: -5 },
   });
-  expect(serialize(scopeB)).toMatchInlineSnapshot(`
-    {
-      "l4dkuf": -5,
-    }
-  `);
+  expect(scopeB.getState($data)).toBe(-5);
+  expect(scopeB.getState($target)).toBe(-5);
 });
 
 test('do not affect original store value', async () => {
+  const $target = createStore(0);
+
   const app = createDomain();
   const source = app.createEvent<{ first?: number; another?: boolean }>();
   const out = splitMap({
     source,
     cases: {
       first: (payload) => payload.first,
+    },
+    targets: {
+      first: $target,
     },
   });
 
@@ -104,10 +114,10 @@ test('do not affect original store value', async () => {
     scope,
     params: { first: 15 },
   });
-  expect(serialize(scope)).toMatchInlineSnapshot(`
-    {
-      "8sunrf": 15,
-    }
-  `);
+
+  expect(scope.getState($data)).toBe(15);
   expect($data.getState()).toBe($data.defaultState);
+
+  expect(scope.getState($target)).toBe(15);
+  expect($target.getState()).toBe($target.defaultState);
 });

--- a/test-typings/split-map.ts
+++ b/test-typings/split-map.ts
@@ -68,6 +68,50 @@ import { splitMap } from '../dist/split-map';
   );
 }
 
+// Allow any unit as source (with targets)
+{
+  const event = createEvent<number>();
+  const $store = createStore(0);
+  const effect = createEffect<string, void>();
+
+  expectType<{ demo: Event<boolean>; __: Event<number> }>(
+    splitMap({
+      source: event,
+      cases: {
+        demo: () => true,
+      },
+      targets: {
+        demo: createEvent<boolean>(),
+        __: createStore<number>(0),
+      },
+    }),
+  );
+  expectType<{ demo: Event<boolean>; __: Event<number> }>(
+    splitMap({
+      source: $store,
+      cases: {
+        demo: () => true,
+      },
+      targets: {
+        demo: createEffect<boolean, void>(),
+        __: createEvent<number>(),
+      },
+    }),
+  );
+  expectType<{ demo: Event<boolean>; __: Event<string> }>(
+    splitMap({
+      source: effect,
+      cases: {
+        demo: () => true,
+      },
+      targets: {
+        demo: createStore<boolean>(true),
+        __: createEffect<string, void>(),
+      },
+    }),
+  );
+}
+
 // Has default case
 {
   expectType<{ __: Event<number> }>(
@@ -75,6 +119,26 @@ import { splitMap } from '../dist/split-map';
   );
   expectType<{ __: Event<{ demo: number }> }>(
     splitMap({ source: createEvent<{ demo: number }>(), cases: {} }),
+  );
+
+  // with targets
+  expectType<{ __: Event<number> }>(
+    splitMap({
+      source: createEvent<number>(),
+      cases: {},
+      targets: {
+        __: createEvent<number>(),
+      },
+    }),
+  );
+  expectType<{ __: Event<{ demo: number }> }>(
+    splitMap({
+      source: createEvent<{ demo: number }>(),
+      cases: {},
+      targets: {
+        __: createEvent<{ demo: number }>(),
+      },
+    }),
   );
 }
 
@@ -93,4 +157,147 @@ import { splitMap } from '../dist/split-map';
       },
     }),
   );
+
+  expectType<{ example: Event<string>; __: Event<Payload> }>(
+    splitMap({
+      source,
+      cases: {
+        example: (object) => object.key,
+      },
+      targets: {
+        example: createEvent<string>(),
+        __: createEvent<Payload>(),
+      },
+    }),
+  );
+}
+
+// Allow void units in targets
+{
+  splitMap({
+    source: createEvent<{ name?: string; age?: number }>(),
+    cases: {
+      ageNumbered: ({ age }) => age,
+      nameStringed: ({ name }) => name,
+      doSome: () => true,
+      doAnother: () => null,
+    },
+    targets: {
+      ageNumbered: createEvent<number>(),
+      nameStringed: [createStore<string>(''), createEffect<string, void>()],
+      doSome: [createEvent<boolean>(), createEvent<void>()],
+      doAnother: createEvent<void>(),
+      __: createEvent<void>(),
+    },
+  });
+}
+
+// Allow array of units in targets default case
+{
+  splitMap({
+    source: createEvent<string>(),
+    cases: {},
+    targets: {
+      __: [
+        createEvent<string>(),
+        createStore<string>(''),
+        createEffect<string, void>(),
+      ],
+    },
+  });
+
+  // Allow void units in targets default case
+  splitMap({
+    source: createEvent<string>(),
+    cases: {},
+    targets: {
+      __: [createStore(''), createEvent<void>(), createEffect<void, void>()],
+    },
+  });
+}
+
+// Expect matching targets types with cases
+{
+  splitMap({
+    source: createEvent<{ name?: string; age?: number }>(),
+    cases: {
+      ageNumbered: ({ age }) => age,
+      nameStringed: ({ name }) => name,
+      doSome: () => true,
+      doAnother: () => null,
+      foo: () => '',
+    },
+    targets: {
+      // @ts-expect-error
+      ageNumbered: createEvent<string>(),
+      nameStringed: [
+        // @ts-expect-error
+        createStore<number>(''),
+        // @ts-expect-error
+        createEffect<number, void>(),
+      ],
+      doSome: [
+        // @ts-expect-error
+        createEvent<string>(),
+        createEvent<void>(),
+      ],
+      doAnother: [
+        // @ts-expect-error
+        createEvent<boolean>(),
+        // @ts-expect-error
+        createEffect<string, void>(),
+      ],
+      foo: [
+        // @ts-expect-error
+        createEvent<number>(),
+        // @ts-expect-error
+        createEvent<number>(),
+      ],
+    },
+  });
+
+  splitMap({
+    source: createEvent<string>(),
+    cases: {},
+    targets: {
+      // @ts-expect-error
+      __: createEvent<number>(),
+    },
+  });
+
+  splitMap({
+    source: createEvent<Array<number>>(),
+    cases: {},
+    targets: {
+      __: [
+        // @ts-expect-error
+        createStore<string>(''),
+        // @ts-expect-error
+        createEvent<number>(),
+        // @ts-expect-error
+        createEffect<boolean, void>(),
+
+        createEvent<void>(),
+      ],
+    },
+  });
+}
+
+// case payloads should extend target units
+{
+  splitMap({
+    source: createEvent<{ first?: string; second?: number }>(),
+    cases: {
+      first: ({ first }) => first, // will be string
+      second: ({ second }) => second, // will be number
+    },
+    targets: {
+      // string should extend string | null
+      first: createEvent<string | null>(),
+
+      // number should extend number | null
+      // TODO: but not string, should expect error
+      second: [createEvent<number | null>(), createEvent<string>()],
+    },
+  });
 }


### PR DESCRIPTION
### Description

This PR partially resolves [this issue](https://github.com/effector/patronum/issues/123).
Often we need the same behavior as in split — react to derived events received from `cases` and trigger the corresponding units. In `targets` field we can pass object with the same keys as in `cases` and values with `units` to trigger on the corresponding event.

### Checklist

- [ ] Add tests to `src/method-name/method-name.test.ts`
- [ ] Add **fork** tests to `src/method-name/method-name.fork.test.ts`
- [ ] Add **type** tests to `test-typings/method-name.ts`
  - Use `// @ts-expect-error` to mark expected type error
  - `import { expectType } from 'tsd'` to check expected return type
- [ ] Add documentation in `src/method-name/readme.md`
  - Add header `Patronum/MethodName`
  - Add section with overloads, if have
  - Add `Motivation`, `Formulae`, `Arguments` and `Return` sections for each overload
  - Add useful examples in `Example` section for each overload
- [ ] Add section to `README.md` in the repository root
  - Add method to the table of contents into correct category `- [MethodName](#methodname) - description.`
  - Add section `## MethodName`
  - Add `[Method documentation & API](/src/method-name)` into section
  - Add simple example
