### PR TITLE
Change typing in some methods

### DIFF
--- a/integration/custom/test/integration.spec.ts
+++ b/integration/custom/test/integration.spec.ts
@@ -1,4 +1,4 @@
-import { createEffect, Event } from 'effector';
+import { createEffect, EventCallable } from 'effector';
 import { status } from '@effector/patronum/status';
 import { pending } from '@effector/patronum/macro';
 
@@ -41,7 +41,7 @@ test('pending macro works as expected', () => {
   expect($pending.sid).toMatchInlineSnapshot(`"-hszfx7|a4upb3"`);
 });
 
-function waitFor<T>(unit: Event<T>) {
+function waitFor<T>(unit: EventCallable<T>) {
   return new Promise<T>((resolve) => {
     const unsubscribe = unit.watch((payload) => {
       resolve(payload);

--- a/src/combine-events/index.ts
+++ b/src/combine-events/index.ts
@@ -2,7 +2,7 @@ import {
   createEvent,
   createStore,
   Effect,
-  Event,
+  EventCallable,
   EventAsReturnType,
   is,
   sample,
@@ -16,17 +16,17 @@ type Tuple<T = unknown> = [T] | T[];
 type Shape = Record<string, unknown> | Tuple;
 
 type Events<Result> = {
-  [Key in keyof Result]: Event<Result[Key]>;
+  [Key in keyof Result]: EventCallable<Result[Key]>;
 };
 
 type ReturnTarget<Result, Target> = Target extends Store<infer S>
   ? S extends Result
     ? Store<S>
     : Store<Result>
-  : Target extends Event<infer P>
+  : Target extends EventCallable<infer P>
   ? P extends Result
-    ? Event<P>
-    : Event<Result>
+    ? EventCallable<P>
+    : EventCallable<Result>
   : Target extends Effect<infer P, infer D, infer F>
   ? P extends Result
     ? Effect<P, D, F>

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -2,7 +2,7 @@ import {
   Stack,
   Node,
   Effect,
-  Event,
+  EventCallable,
   is,
   Store,
   Unit,
@@ -120,7 +120,7 @@ function watchDomain(domain: Domain, config: Config) {
 }
 
 function watchUnit(
-  unit: Store<any> | Event<any> | Effect<any, any, any>,
+  unit: Store<any> | EventCallable<any> | Effect<any, any, any>,
   config: Config,
 ) {
   if (is.store(unit)) {

--- a/src/once/index.ts
+++ b/src/once/index.ts
@@ -1,6 +1,6 @@
 import {
   Unit,
-  Event,
+  EventCallable,
   EventAsReturnType,
   is,
   sample,
@@ -28,7 +28,7 @@ export function once<T>(
 
   const $canTrigger = createStore<boolean>(true);
 
-  const trigger: Event<T> = sample({
+  const trigger: EventCallable<T> = sample({
     source,
     filter: $canTrigger,
   });

--- a/src/snapshot/index.ts
+++ b/src/snapshot/index.ts
@@ -1,4 +1,4 @@
-import { Effect, Event, Store, StoreWritable, Unit, createStore, sample } from 'effector';
+import { Effect, EventCallable, Store, StoreWritable, Unit, createStore, sample } from 'effector';
 
 type NoInfer<T> = [T][T extends any ? 0 : never];
 
@@ -8,7 +8,7 @@ export function snapshot<SourceType, TargetType = SourceType>({
   fn = (value: SourceType) => value as unknown as TargetType,
 }: {
   source: Store<SourceType>;
-  clock?: Event<any> | Effect<any, any, any> | Store<any>;
+  clock?: EventCallable<any> | Effect<any, any, any> | Store<any>;
   fn?(value: SourceType): TargetType;
 }): StoreWritable<NoInfer<TargetType>> {
   const defaultValue = fn(source.defaultState);

--- a/src/split-map/index.ts
+++ b/src/split-map/index.ts
@@ -1,4 +1,4 @@
-import { Event, is, Store, Unit } from 'effector';
+import { EventCallable, is, Store, Unit } from 'effector';
 
 export function splitMap<
   S,
@@ -11,12 +11,12 @@ export function splitMap<
   cases: Cases;
 }): {
   [K in keyof Cases]: Cases[K] extends (p: S) => infer R
-    ? Event<Exclude<R, undefined>>
+    ? EventCallable<Exclude<R, undefined>>
     : never;
-} & { __: Event<S> } {
-  const result: Record<string, Event<any> | Store<any>> = {};
+} & { __: EventCallable<S> } {
+  const result: Record<string, EventCallable<any> | Store<any>> = {};
 
-  let current = is.store(source) ? source.updates : (source as Event<S>);
+  let current = is.store(source) ? source.updates : (source as EventCallable<S>);
 
   for (const key in cases) {
     if (key in cases) {

--- a/src/throttle/index.ts
+++ b/src/throttle/index.ts
@@ -2,7 +2,7 @@ import {
   createEffect,
   createEvent,
   createStore,
-  Event,
+  EventCallable,
   is,
   sample,
   Store,
@@ -10,7 +10,7 @@ import {
   UnitTargetable,
 } from 'effector';
 
-type EventAsReturnType<Payload> = any extends Payload ? Event<Payload> : never;
+type EventAsReturnType<Payload> = any extends Payload ? EventCallable<Payload> : never;
 
 export function throttle<T>(
   source: Unit<T>,
@@ -47,7 +47,7 @@ export function throttle<T>(
   const $timeout = toStoreNumber(timeout);
 
   const timerFx = createEffect<number, void>({
-    name: `throttle(${(source as Event<T>).shortName || source.kind}) effect`,
+    name: `throttle(${(source as EventCallable<T>).shortName || source.kind}) effect`,
     handler: (timeout) => new Promise((resolve) => setTimeout(resolve, timeout)),
   });
 

--- a/test-library.d.ts
+++ b/test-library.d.ts
@@ -1,4 +1,4 @@
-import { Unit, Event, Store, Effect } from 'effector';
+import { Unit, EventCallable, Store, Effect } from 'effector';
 
 export function argumentHistory(fn: jest.Mock): Array<unknown>;
 export function argumentsHistory(fn: jest.Mock): Array<Array<unknown>>;
@@ -19,9 +19,9 @@ export function wait(ms: number): Promise<void>;
 export function waitFor<T>(unit: Unit<T>): Promise<T>;
 
 export function watch<T>(
-  unit: Event<T> | Store<T> | Effect<T, any, any>,
+  unit: EventCallable<T> | Store<T> | Effect<T, any, any>,
 ): jest.Mock<T, [T]>;
 
 export function monitor(
-  units: Array<Event<any> | Store<any> | Effect<any, any, any>>,
+  units: Array<EventCallable<any> | Store<any> | Effect<any, any, any>>,
 ): () => Array<[string, any]>;


### PR DESCRIPTION
### Description

<!-- Why we should add this method? -->

### Checklist for a new method

- [ ] Create a directory for the new method in the `src` directory in `param-case`
- [ ] Place the source code to `src/method-name/index.ts` in ESModules export in `camelCase` **named** export
- [ ] Add tests to `src/method-name/method-name.test.ts`
- [ ] Add **fork** tests to `src/method-name/method-name.fork.test.ts`
- [ ] Add **type** tests to `test-typings/method-name.ts`
  - Use `// @ts-expect-error` to mark expected type error
  - `import { expectType } from 'tsd'` to check expected return type
- [ ] Add documentation in `src/method-name/readme.md`
  - Add header `Patronum/MethodName`
  - Add section with overloads, if have
  - Add `Motivation`, `Formulae`, `Arguments` and `Return` sections for each overload
  - Add useful examples in `Example` section for each overload
- [ ] Fill frontmatter in `src/method-name/readme.md`
  - Add `title`. Make sure it uses camelCase syntax just like the method itself
  - Add `slug`. Use param-case to write it. In most cases it will be just like `title`
  - Add `desription` with one short sentence describing what method useful for
  - Add `group`. To categorize method on `/operators` page. Full list of available groups, you can see in [documentation/src/content/config.ts](../documentation/src/content/config.ts)
