### PR TITLE
feat: add skip & take

### DIFF
--- a/src/skip/index.ts
+++ b/src/skip/index.ts
@@ -1,0 +1,44 @@
+import { Event, Store, Unit, createEvent, createStore, is, sample } from 'effector';
+
+export function skip<T>({
+  clock,
+  count,
+  reset,
+}: {
+  clock: Unit<T>;
+  count: Store<number> | number;
+  reset?: Unit<T>;
+}): Event<T> {
+  const $count = is.store(count) ? count : createStore(count);
+
+  const $skipped = createStore(0);
+
+  reset = is.unit(reset) ? reset : createEvent();
+
+  const $canTrigger = sample({
+    source: [$skipped, $count],
+    fn: ([skp, cnt]) => skp >= cnt,
+  });
+
+  const event = sample({
+    clock,
+    source: $skipped,
+    filter: $canTrigger,
+    fn: (_, params) => params,
+  });
+
+  sample({
+    clock,
+    source: $skipped,
+    filter: $canTrigger.map((can) => !can),
+    fn: (skp) => skp + 1,
+    target: $skipped,
+  });
+
+  sample({
+    clock: [$count, reset],
+    target: $skipped.reinit,
+  });
+
+  return event;
+}

--- a/src/take/index.ts
+++ b/src/take/index.ts
@@ -1,0 +1,44 @@
+import { Event, Store, Unit, createEvent, createStore, is, sample } from 'effector';
+
+export function skip<T>({
+  clock,
+  count,
+  reset,
+}: {
+  clock: Unit<T>;
+  count: Store<number> | number;
+  reset?: Unit<T>;
+}): Event<T> {
+  const $count = is.store(count) ? count : createStore(count);
+
+  const $skipped = createStore(0);
+
+  reset = is.unit(reset) ? reset : createEvent();
+
+  const $canTrigger = sample({
+    source: [$skipped, $count],
+    fn: ([skp, cnt]) => skp >= cnt,
+  });
+
+  const event = sample({
+    clock,
+    source: $skipped,
+    filter: $canTrigger,
+    fn: (_, params) => params,
+  });
+
+  sample({
+    clock,
+    source: $skipped,
+    filter: $canTrigger.map((can) => !can),
+    fn: (skp) => skp + 1,
+    target: $skipped,
+  });
+
+  sample({
+    clock: [$count, reset],
+    target: $skipped.reinit,
+  });
+
+  return event;
+}


### PR DESCRIPTION
### Description

I think everyone had to write logic for limiting calls to effects or events. For example, limiting the number of repeated requests (take) or displaying some kind of warning if the user abuses a button or other interactive element (skip).
They are based on abstract and repeating elements that can be put into separate operators - skip & take.


These operators were inspired by their rxjs analogs:
skip - https://rxjs.dev/api/index/function/skip;
take - https://rxjs.dev/api/index/function/take.

I know the effector API tries to be minimalistic. I agree with this. But I don't consider these particular operators redundant.
If you think otherwise, you can safely close this PR by writing feedback.

In case of positive feedback, I am ready to complete the entire checklist for adding new operators and follow your comments in order to bring these operators to release.

### Checklist for a new method

- [ ] Create a directory for the new method in the `src` directory in `param-case`
- [ ] Place the source code to `src/method-name/index.ts` in ESModules export in `camelCase` **named** export
- [ ] Add tests to `src/method-name/method-name.test.ts`
- [ ] Add **fork** tests to `src/method-name/method-name.fork.test.ts`
- [ ] Add **type** tests to `test-typings/method-name.ts`
  - Use `// @ts-expect-error` to mark expected type error
  - `import { expectType } from 'tsd'` to check expected return type
- [ ] Add documentation in `src/method-name/readme.md`
  - Add header `Patronum/MethodName`
  - Add section with overloads, if have
  - Add `Motivation`, `Formulae`, `Arguments` and `Return` sections for each overload
  - Add useful examples in `Example` section for each overload
- [ ] Fill frontmatter in `src/method-name/readme.md`
  - Add `title`. Make sure it uses camelCase syntax just like the method itself
  - Add `slug`. Use param-case to write it. In most cases it will be just like `title`
  - Add `desription` with one short sentence describing what method useful for
  - Add `group`. To categorize method on `/operators` page. Full list of available groups, you can see in [documentation/src/content/config.ts](https://github.com/effector/patronum/blob/main/documentation/src/content/config.ts)
